### PR TITLE
Wrap export cart in expandable section

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -626,22 +626,70 @@ def render_marking_tab():
     st.write("Preview row:")
     st.dataframe(pd.DataFrame([one_row]), use_container_width=True)
 
-    # Destination tab (optional)
-    st.markdown("**Destination tab (optional):**")
-    dest_mode = st.radio(
-        "Where to send?",
-        ["Use defaults", "Specify by gid", "Specify by name"],
-        horizontal=True,
-        index=0
-    )
-    dest_gid = None
-    dest_name = None
-    if dest_mode == "Specify by gid":
-        dest_gid = st.number_input("sheet_gid", value=DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else 0, step=1)
-        if int(dest_gid) <= 0:
-            dest_gid = None
-    elif dest_mode == "Specify by name":
-        dest_name = st.text_input("sheet_name", value=DEFAULT_TARGET_SHEET_NAME or "")
+    with st.expander("Advanced export options", expanded=False):
+        st.markdown("**Destination tab (optional):**")
+        dest_mode = st.radio(
+            "Where to send?",
+            ["Use defaults", "Specify by gid", "Specify by name"],
+            horizontal=True,
+            index=0
+        )
+        dest_gid = None
+        dest_name = None
+        if dest_mode == "Specify by gid":
+            dest_gid = st.number_input("sheet_gid", value=DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else 0, step=1)
+            if int(dest_gid) <= 0:
+                dest_gid = None
+        elif dest_mode == "Specify by name":
+            dest_name = st.text_input("sheet_name", value=DEFAULT_TARGET_SHEET_NAME or "")
+        else:
+            dest_gid = DEFAULT_TARGET_SHEET_GID
+            dest_name = DEFAULT_TARGET_SHEET_NAME
+
+        st.divider()
+        st.subheader("7) Export Cart (build multiple rows, then export/send)")
+
+        if "export_cart" not in st.session_state:
+            st.session_state["export_cart"] = []
+
+        col1, col2, col3, col4 = st.columns([1,1,1,1])
+        with col1:
+            if st.button("➕ Add current row to cart"):
+                st.session_state["export_cart"].append(one_row)
+        with col2:
+            if st.button("🧹 Clear cart"):
+                st.session_state["export_cart"] = []
+        with col3:
+            st.caption(f"{len(st.session_state['export_cart'])} row(s) in cart")
+        with col4:
+            if st.session_state["export_cart"]:
+                if st.button("📤 Send cart to Google Sheet (Webhook)"):
+                    try:
+                        rows_to_send = st.session_state.get("edited_cart_rows") or st.session_state["export_cart"]
+                        result = _post_rows_to_sheet(
+                            rows_to_send,
+                            sheet_name=dest_name if dest_name else None,
+                            sheet_gid=int(dest_gid) if dest_gid else None
+                        )
+                        st.success(f"Appended {result.get('appended', len(rows_to_send))} rows ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})")
+                    except Exception as e:
+                        st.error(f"Failed to send: {e}")
+
+        if st.session_state["export_cart"]:
+            cart_df = pd.DataFrame(st.session_state["export_cart"], columns=[
+                "studentcode","name","assignment","score","comments","date","level","link"
+            ])
+            st.write("Edit score/comments here if you like, then download or send:")
+            edited_cart = st.data_editor(cart_df, use_container_width=True, num_rows="dynamic")
+            st.session_state["edited_cart_rows"] = edited_cart.to_dict(orient="records")
+
+            cart_csv = edited_cart.to_csv(index=False)
+            cart_tsv = edited_cart.to_csv(index=False, sep="\t")
+            st.download_button("⬇️ Download cart as CSV", data=cart_csv, file_name="grades_export.csv", mime="text/csv")
+            with st.expander("Copy-friendly TSV (paste straight into Google Sheet)"):
+                st.code(cart_tsv.strip(), language="text")
+        else:
+            st.info("Cart is empty — add the row above to start building a batch.")
 
     # One-row actions
     c1, c2 = st.columns(2)
@@ -654,60 +702,11 @@ def render_marking_tab():
                 result = _post_rows_to_sheet(
                     [one_row],
                     sheet_name=dest_name if dest_name else None,
-                    sheet_gid=int(dest_gid) if dest_gid else (DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else None)
+                    sheet_gid=int(dest_gid) if dest_gid else None
                 )
                 st.success(f"Appended {result.get('appended', 1)} row ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})")
             except Exception as e:
                 st.error(f"Failed to send: {e}")
-
-    st.divider()
-
-    # =======================
-    # 7) Export Cart (multi-row → Google Sheet)
-    # =======================
-    st.subheader("7) Export Cart (build multiple rows, then export/send)")
-
-    if "export_cart" not in st.session_state:
-        st.session_state["export_cart"] = []
-
-    col1, col2, col3, col4 = st.columns([1,1,1,1])
-    with col1:
-        if st.button("➕ Add current row to cart"):
-            st.session_state["export_cart"].append(one_row)
-    with col2:
-        if st.button("🧹 Clear cart"):
-            st.session_state["export_cart"] = []
-    with col3:
-        st.caption(f"{len(st.session_state['export_cart'])} row(s) in cart")
-    with col4:
-        if st.session_state["export_cart"]:
-            if st.button("📤 Send cart to Google Sheet (Webhook)"):
-                try:
-                    rows_to_send = st.session_state.get("edited_cart_rows") or st.session_state["export_cart"]
-                    result = _post_rows_to_sheet(
-                        rows_to_send,
-                        sheet_name=dest_name if dest_name else None,
-                        sheet_gid=int(dest_gid) if dest_gid else (DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else None)
-                    )
-                    st.success(f"Appended {result.get('appended', len(rows_to_send))} rows ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})")
-                except Exception as e:
-                    st.error(f"Failed to send: {e}")
-
-    if st.session_state["export_cart"]:
-        cart_df = pd.DataFrame(st.session_state["export_cart"], columns=[
-            "studentcode","name","assignment","score","comments","date","level","link"
-        ])
-        st.write("Edit score/comments here if you like, then download or send:")
-        edited_cart = st.data_editor(cart_df, use_container_width=True, num_rows="dynamic")
-        st.session_state["edited_cart_rows"] = edited_cart.to_dict(orient="records")
-
-        cart_csv = edited_cart.to_csv(index=False)
-        cart_tsv = edited_cart.to_csv(index=False, sep="\t")
-        st.download_button("⬇️ Download cart as CSV", data=cart_csv, file_name="grades_export.csv", mime="text/csv")
-        with st.expander("Copy-friendly TSV (paste straight into Google Sheet)"):
-            st.code(cart_tsv.strip(), language="text")
-    else:
-        st.info("Cart is empty — add the row above to start building a batch.")
 
 
 # Run standalone OR import into your tabs and call with:


### PR DESCRIPTION
## Summary
- Nest destination tab selection and export cart controls inside a new `st.expander` labelled "Advanced export options".
- Keep the one-row preview and "Send this row" button outside the expander so they're visible by default.

## Testing
- `pytest -q`
- `python -m py_compile grammar.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0fc71275483219c03bdc8437b6747