### PR TITLE
Refactor marking tab into helper functions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -293,37 +293,17 @@ def _post_rows_to_sheet(rows, sheet_name: str | None = None, sheet_gid: int | No
     return data
 
 # =============================================================================
-# UI: MARKING TAB
+# UI helper functions
 # =============================================================================
-def render_marking_tab():
-    _ensure_firebase_clients()
 
-    st.title("📝 Reference & Student Work Share")
-
-    # --- Load Data (Sheets) ---
-    try:
-        df_students = load_marking_students(STUDENTS_CSV_URL)
-    except Exception as e:
-        st.error(f"Could not load students: {e}")
-        return
-
-    try:
-        ref_df = load_marking_ref_answers(REF_ANSWERS_URL)
-        if "assignment" not in ref_df.columns:
-            st.warning("No 'assignment' column found in reference answers sheet.")
-            return
-    except Exception as e:
-        st.error(f"Could not load reference answers: {e}")
-        return
-
-    # --- Column mapping ---
+def select_student(df_students):
+    """Select a student and resolve Firestore document."""
     name_col = col_lookup(df_students, "name")
     code_col = col_lookup(df_students, "studentcode")
     if not name_col or not code_col:
         st.error("Required columns 'name' or 'studentcode' not found in students sheet.")
-        return
+        return None, None, None, None
 
-    # --- Student search/select (persistent) ---
     st.subheader("1) Search & Select Student")
     with st.form("marking_student_form"):
         search_student = st.text_input("Type student name or code...", key="tab7_search_student")
@@ -331,8 +311,8 @@ def render_marking_tab():
 
     if submitted_student and search_student:
         mask = (
-            df_students[name_col].astype(str).str.contains(search_student, case=False, na=False) |
-            df_students[code_col].astype(str).str.contains(search_student, case=False, na=False)
+            df_students[name_col].astype(str).str.contains(search_student, case=False, na=False)
+            | df_students[code_col].astype(str).str.contains(search_student, case=False, na=False)
         )
         students_filtered = df_students[mask].copy()
     else:
@@ -340,9 +320,8 @@ def render_marking_tab():
 
     if students_filtered.empty:
         st.info("No students match your search. Try a different query.")
-        return
+        st.stop()
 
-    # Build options as IDs (codes) with format_func labels
     codes = students_filtered[code_col].astype(str).tolist()
     code_to_name = dict(zip(students_filtered[code_col].astype(str), students_filtered[name_col].astype(str)))
 
@@ -352,12 +331,12 @@ def render_marking_tab():
     selected_student_code = st.selectbox("Select Student", codes, format_func=_fmt_student, key="tab7_selected_code")
     if not selected_student_code:
         st.warning("Select a student to continue.")
-        return
+        st.stop()
 
     sel_rows = students_filtered[students_filtered[code_col] == selected_student_code]
     if sel_rows.empty:
         st.warning("Selected student not found.")
-        return
+        st.stop()
     student_row = sel_rows.iloc[0]
     student_code = selected_student_code
     student_name = str(student_row.get(name_col, "")).strip()
@@ -366,7 +345,6 @@ def render_marking_tab():
     st.subheader("Student Code")
     st.code(student_code)
 
-    # --- Resolve Firestore doc under drafts_v2 ---
     st.subheader("1b) Match to Firestore student document (drafts_v2)")
     if "tab7_effective_student_doc" not in st.session_state:
         st.session_state["tab7_effective_student_doc"] = None
@@ -379,7 +357,7 @@ def render_marking_tab():
     with colr2:
         manual_override = st.text_input(
             "Manual override (exact drafts_v2 doc id)",
-            value=st.session_state.get("tab7_effective_student_doc") or ""
+            value=st.session_state.get("tab7_effective_student_doc") or "",
         )
 
     if manual_override.strip():
@@ -415,8 +393,11 @@ def render_marking_tab():
         st.stop()
 
     st.success(f"Using Firestore doc: drafts_v2/{effective_doc}")
+    return student_code, student_name, student_row, effective_doc
 
-    # --- Student submissions ---
+
+def choose_submission(effective_doc):
+    """Choose a submission (lesson) to mark."""
     st.subheader("2) Pick a Submission to Mark (from drafts_v2 → lessons)")
     colA, colB, colC = st.columns([1, 1, 1])
     with colA:
@@ -435,12 +416,14 @@ def render_marking_tab():
 
     if search_lessons:
         q = search_lessons.strip().lower()
+
         def _row_match(r):
             return (
-                (str(r.get("title","")).lower().find(q) >= 0) or
-                (str(r.get("lesson_id","")).lower().find(q) >= 0) or
-                (str(r.get("answer_text","")).lower().find(q) >= 0)
+                (str(r.get("title", "")).lower().find(q) >= 0)
+                or (str(r.get("lesson_id", "")).lower().find(q) >= 0)
+                or (str(r.get("answer_text", "")).lower().find(q) >= 0)
             )
+
         df_view = df_lessons[df_lessons.apply(_row_match, axis=1)].copy()
     else:
         df_view = df_lessons.copy()
@@ -453,41 +436,50 @@ def render_marking_tab():
     df_preview["answer_preview"] = df_preview["answer_text"].fillna("").astype(str).str.slice(0, 160)
     try:
         st.data_editor(
-            df_preview[["title","lesson_id","submitted_at","score","comment","file","answer_preview"]],
+            df_preview[["title", "lesson_id", "submitted_at", "score", "comment", "file", "answer_preview"]],
             use_container_width=True,
             column_config={"file": st.column_config.LinkColumn("File")},
             disabled=True,
             height=300,
         )
     except Exception:
-        st.dataframe(df_preview[["title","lesson_id","submitted_at","score","comment","file","answer_preview"]],
-                     use_container_width=True, height=300)
+        st.dataframe(
+            df_preview[["title", "lesson_id", "submitted_at", "score", "comment", "file", "answer_preview"]],
+            use_container_width=True,
+            height=300,
+        )
 
-    # Persistent submission select (value = lesson_id)
     ids = df_view["lesson_id"].astype(str).tolist()
     id_to_row = df_view.set_index("lesson_id").to_dict(orient="index")
 
     def _fmt_submission(lesson_id: str):
         r = id_to_row.get(lesson_id, {})
-        return f"{r.get('title','')} — {lesson_id} — {r.get('submitted_at','')}"
+        return f"{r.get('title', '')} — {lesson_id} — {r.get('submitted_at', '')}"
 
-    selected_lesson_id = st.selectbox("Choose a submission to mark", ids, format_func=_fmt_submission, key="tab7_selected_submission")
+    selected_lesson_id = st.selectbox(
+        "Choose a submission to mark", ids, format_func=_fmt_submission, key="tab7_selected_submission"
+    )
     chosen_row = df_view[df_view["lesson_id"] == selected_lesson_id].iloc[0]
 
     st.markdown("**Selected submission details:**")
-    st.json({
-        "doc_path": chosen_row.get("doc_path"),
-        "title": chosen_row.get("title"),
-        "lesson_id": chosen_row.get("lesson_id"),
-        "submitted_at": str(chosen_row.get("submitted_at")),
-        "score": chosen_row.get("score"),
-        "comment": chosen_row.get("comment"),
-        "file": chosen_row.get("file"),
-    })
+    st.json(
+        {
+            "doc_path": chosen_row.get("doc_path"),
+            "title": chosen_row.get("title"),
+            "lesson_id": chosen_row.get("lesson_id"),
+            "submitted_at": str(chosen_row.get("submitted_at")),
+            "score": chosen_row.get("score"),
+            "comment": chosen_row.get("comment"),
+            "file": chosen_row.get("file"),
+        }
+    )
+    return chosen_row
 
-    # --- Reference selection (auto-pick link) ---
+
+def pick_reference(ref_df):
+    """Pick a reference answer from the Google Sheet."""
     st.subheader("3) Select Reference Answer (from Google Sheet)")
-    available_assignments = ref_df['assignment'].dropna().astype(str).unique().tolist()
+    available_assignments = ref_df["assignment"].dropna().astype(str).unique().tolist()
     with st.form("marking_assignment_form"):
         search_assign = st.text_input("Search reference titles...", key="tab7_search_assign")
         submitted_assign = st.form_submit_button("Filter references")
@@ -503,15 +495,13 @@ def render_marking_tab():
     ref_answers = []
     ref_link_value = ""
     if assignment:
-        assignment_row = ref_df[ref_df['assignment'].astype(str) == assignment]
+        assignment_row = ref_df[ref_df["assignment"].astype(str) == assignment]
         if not assignment_row.empty:
             row = assignment_row.iloc[0]
-            # Answers
             all_cols = assignment_row.columns.tolist()
             answer_cols = [c for c in all_cols if str(c).startswith("answer")]
             answer_cols = [c for c in answer_cols if pd.notnull(row[c]) and str(row[c]).strip() != ""]
             ref_answers = [str(row[c]) for c in answer_cols]
-            # Auto-pick link (prefers key= / endswith key)
             ref_link_value = _autopick_ref_link_from_row(row)
 
     if ref_answers:
@@ -533,30 +523,38 @@ def render_marking_tab():
     with st.expander("Edit picked link (optional)"):
         ref_link_value = st.text_input("Reference answer link", value=ref_link_value, placeholder="https://...")
 
-    # --- Student Work ---
+    return assignment, answers_combined_str, ref_link_value
+
+
+def mark_submission(student_code, student_name, student_row, chosen_row, assignment, answers_combined_str, ref_link_value):
+    """Enter marking details and build the row for export."""
     st.subheader("4) Student Work")
     student_work = st.text_area(
         "Edit before marking if needed:",
         height=180,
         key="tab7_student_work",
-        value=chosen_row.get("answer_text") or ""
+        value=chosen_row.get("answer_text") or "",
     )
 
-    # --- Grader Inputs: Score + Feedback ---
     st.subheader("4b) Your Marking")
     col_score, col_dummy = st.columns([1, 1])
     with col_score:
-        score_input = st.number_input("Score", min_value=0.0, max_value=10000.0, value=0.0, step=1.0,
-                                      help="Enter the score you want to record")
+        score_input = st.number_input(
+            "Score",
+            min_value=0.0,
+            max_value=10000.0,
+            value=0.0,
+            step=1.0,
+            help="Enter the score you want to record",
+        )
     comments_input = st.text_area("Feedback / Comments", value="", height=120)
 
-    # --- Link Source Selection (ref link vs submission file vs both vs custom) ---
     st.subheader("4c) Link to attach in the sheet")
-    default_idx = 0  # we now always default to the reference answer link
+    default_idx = 0
     link_source = st.selectbox(
         "Pick which link goes into the 'link' column",
         ["Reference answer link", "Submission file link", "Both (reference first)", "Custom..."],
-        index=default_idx
+        index=default_idx,
     )
     custom_link = ""
     if link_source == "Custom...":
@@ -572,7 +570,6 @@ def render_marking_tab():
     else:
         link_value = custom_link.strip()
 
-    # --- Combined copy & downloads ---
     st.subheader("5) Copy Zone (Reference + Student Work)")
     combined_text = (
         "Reference answer:\n"
@@ -581,14 +578,13 @@ def render_marking_tab():
         + (student_work or "")
     )
     st.code(combined_text, language="markdown")
-    st.download_button("📋 Reference Answer (txt)", data=answers_combined_str,
-                       file_name="reference_answer.txt", mime="text/plain")
-    st.download_button("📋 Reference + Student (txt)", data=combined_text,
-                       file_name="ref_and_student.txt", mime="text/plain")
+    st.download_button(
+        "📋 Reference Answer (txt)", data=answers_combined_str, file_name="reference_answer.txt", mime="text/plain"
+    )
+    st.download_button(
+        "📋 Reference + Student (txt)", data=combined_text, file_name="ref_and_student.txt", mime="text/plain"
+    )
 
-    # =======================
-    # 6) Build Sheet Row (for Google Sheets)
-    # =======================
     st.subheader("6) Build Sheet Row (for Google Sheets)")
 
     def _fmt_date(dt):
@@ -599,7 +595,7 @@ def render_marking_tab():
     assign_source = st.selectbox(
         "Assignment value to use",
         ["Use submission title", "Use reference title (if any)", "Custom..."],
-        index=0
+        index=0,
     )
 
     if assign_source == "Use submission title":
@@ -610,67 +606,74 @@ def render_marking_tab():
         assignment_value = st.text_input("Custom assignment text", value=(chosen_row.get("title") or ""))
 
     student_level = str(student_row.get("level", "")).strip()
-    date_value    = _fmt_date(chosen_row.get("submitted_at"))
+    date_value = _fmt_date(chosen_row.get("submitted_at"))
 
     one_row = {
         "studentcode": student_code,
-        "name":        student_name,
-        "assignment":  assignment_value,
-        "score":       str(score_input) if score_input is not None else "",
-        "comments":    comments_input or "",
-        "date":        date_value,
-        "level":       student_level,
-        "link":        link_value,
+        "name": student_name,
+        "assignment": assignment_value,
+        "score": str(score_input) if score_input is not None else "",
+        "comments": comments_input or "",
+        "date": date_value,
+        "level": student_level,
+        "link": link_value,
     }
+    return one_row
 
+
+def export_row(one_row):
+    """Preview, download, or export the built row."""
     st.write("Preview row:")
     st.dataframe(pd.DataFrame([one_row]), use_container_width=True)
 
-    # Destination tab (optional)
     st.markdown("**Destination tab (optional):**")
     dest_mode = st.radio(
         "Where to send?",
         ["Use defaults", "Specify by gid", "Specify by name"],
         horizontal=True,
-        index=0
+        index=0,
     )
     dest_gid = None
     dest_name = None
     if dest_mode == "Specify by gid":
-        dest_gid = st.number_input("sheet_gid", value=DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else 0, step=1)
+        dest_gid = st.number_input(
+            "sheet_gid", value=DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else 0, step=1
+        )
         if int(dest_gid) <= 0:
             dest_gid = None
     elif dest_mode == "Specify by name":
         dest_name = st.text_input("sheet_name", value=DEFAULT_TARGET_SHEET_NAME or "")
 
-    # One-row actions
     c1, c2 = st.columns(2)
     with c1:
         row_csv = pd.DataFrame([one_row]).to_csv(index=False)
-        st.download_button("⬇️ Download this row (CSV)", data=row_csv, file_name="grade_row.csv", mime="text/csv")
+        st.download_button(
+            "⬇️ Download this row (CSV)", data=row_csv, file_name="grade_row.csv", mime="text/csv"
+        )
     with c2:
         if st.button("📤 Send this row to Google Sheet (Webhook)"):
             try:
                 result = _post_rows_to_sheet(
                     [one_row],
                     sheet_name=dest_name if dest_name else None,
-                    sheet_gid=int(dest_gid) if dest_gid else (DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else None)
+                    sheet_gid=int(dest_gid)
+                    if dest_gid
+                    else (DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else None),
                 )
-                st.success(f"Appended {result.get('appended', 1)} row ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})")
+                st.success(
+                    f"Appended {result.get('appended', 1)} row ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})"
+                )
             except Exception as e:
                 st.error(f"Failed to send: {e}")
 
     st.divider()
 
-    # =======================
-    # 7) Export Cart (multi-row → Google Sheet)
-    # =======================
     st.subheader("7) Export Cart (build multiple rows, then export/send)")
 
     if "export_cart" not in st.session_state:
         st.session_state["export_cart"] = []
 
-    col1, col2, col3, col4 = st.columns([1,1,1,1])
+    col1, col2, col3, col4 = st.columns([1, 1, 1, 1])
     with col1:
         if st.button("➕ Add current row to cart"):
             st.session_state["export_cart"].append(one_row)
@@ -687,32 +690,73 @@ def render_marking_tab():
                     result = _post_rows_to_sheet(
                         rows_to_send,
                         sheet_name=dest_name if dest_name else None,
-                        sheet_gid=int(dest_gid) if dest_gid else (DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else None)
+                        sheet_gid=int(dest_gid)
+                        if dest_gid
+                        else (DEFAULT_TARGET_SHEET_GID if DEFAULT_TARGET_SHEET_GID else None),
                     )
-                    st.success(f"Appended {result.get('appended', len(rows_to_send))} rows ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})")
+                    st.success(
+                        f"Appended {result.get('appended', len(rows_to_send))} rows ✅  → {result.get('sheetName')} (gid {result.get('sheetId')})"
+                    )
                 except Exception as e:
                     st.error(f"Failed to send: {e}")
 
     if st.session_state["export_cart"]:
-        cart_df = pd.DataFrame(st.session_state["export_cart"], columns=[
-            "studentcode","name","assignment","score","comments","date","level","link"
-        ])
+        cart_df = pd.DataFrame(
+            st.session_state["export_cart"],
+            columns=["studentcode", "name", "assignment", "score", "comments", "date", "level", "link"],
+        )
         st.write("Edit score/comments here if you like, then download or send:")
         edited_cart = st.data_editor(cart_df, use_container_width=True, num_rows="dynamic")
         st.session_state["edited_cart_rows"] = edited_cart.to_dict(orient="records")
 
         cart_csv = edited_cart.to_csv(index=False)
         cart_tsv = edited_cart.to_csv(index=False, sep="\t")
-        st.download_button("⬇️ Download cart as CSV", data=cart_csv, file_name="grades_export.csv", mime="text/csv")
+        st.download_button(
+            "⬇️ Download cart as CSV", data=cart_csv, file_name="grades_export.csv", mime="text/csv"
+        )
         with st.expander("Copy-friendly TSV (paste straight into Google Sheet)"):
             st.code(cart_tsv.strip(), language="text")
     else:
         st.info("Cart is empty — add the row above to start building a batch.")
+# =============================================================================
+# UI: MARKING TAB
+# =============================================================================
+def render_marking_tab():
+    _ensure_firebase_clients()
 
+    st.title("📝 Reference & Student Work Share")
+
+    try:
+        df_students = load_marking_students(STUDENTS_CSV_URL)
+    except Exception as e:
+        st.error(f"Could not load students: {e}")
+        return
+
+    try:
+        ref_df = load_marking_ref_answers(REF_ANSWERS_URL)
+        if "assignment" not in ref_df.columns:
+            st.warning("No 'assignment' column found in reference answers sheet.")
+            return
+    except Exception as e:
+        st.error(f"Could not load reference answers: {e}")
+        return
+
+    student_code, student_name, student_row, effective_doc = select_student(df_students)
+    chosen_row = choose_submission(effective_doc)
+    assignment, answers_combined_str, ref_link_value = pick_reference(ref_df)
+    one_row = mark_submission(
+        student_code,
+        student_name,
+        student_row,
+        chosen_row,
+        assignment,
+        answers_combined_str,
+        ref_link_value,
+    )
+    export_row(one_row)
 
 # Run standalone OR import into your tabs and call with:
 # with tabs[7]:
 #     render_marking_tab()
 if __name__ == "__main__":
     render_marking_tab()
-


### PR DESCRIPTION
## Summary
- break up the marking workflow into `select_student`, `choose_submission`, `pick_reference`, `mark_submission`, and `export_row`
- streamline `render_marking_tab` to load data and invoke new helpers

## Testing
- `python -m py_compile grammar.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0fc7398d88321bf7c9af4a63be232