### PR TITLE
Fix stray U+240A symbol

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -277,7 +277,7 @@ def load_student_lessons_from_drafts_doc(student_doc_id: str, limit: int = 200) 
     return df
 
 # --- Webhook helper -----------------------------------------------------------
-def _post_rows_to_sheet(rows, sheet_name: str | None = None, sheet_gid: int | None = None) -> dict:␊
+def _post_rows_to_sheet(rows, sheet_name: str | None = None, sheet_gid: int | None = None) -> dict:
     """POST rows to the Apps Script webhook. Supports optional tab selection."""
     url = st.secrets.get("G_SHEETS_WEBHOOK_URL", G_SHEETS_WEBHOOK_URL)
     token = st.secrets.get("G_SHEETS_WEBHOOK_TOKEN", G_SHEETS_WEBHOOK_TOKEN)


### PR DESCRIPTION
## Summary
- remove "␊" symbol after `_post_rows_to_sheet` definition
- normalize line endings to LF

## Testing
- `python -m py_compile grammar.py`
- `pytest`
- `rg '\xE2\x90\x8A'`


------
https://chatgpt.com/codex/tasks/task_e_68b15e24d03083218b27fd5613d93c0e