### PR TITLE
Use public firebase_admin API to check app initialization

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -77,7 +77,9 @@ def _ensure_firebase_clients():
         pass
     if not bucket_name:
         bucket_name = os.environ.get("FIREBASE_STORAGE_BUCKET")
-    if not firebase_admin._apps:
+    try:
+        firebase_admin.get_app()
+    except ValueError:
         cfg = {"storageBucket": bucket_name} if bucket_name else {}
         firebase_admin.initialize_app(credentials.Certificate(cred_dict), cfg)
     _DB = firestore.client()


### PR DESCRIPTION
## Summary
- Replace private `firebase_admin._apps` check with a `firebase_admin.get_app()` try/except
- Initialize Firebase app only if `get_app()` raises `ValueError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b160a774548321a942446081563dc4