### PR TITLE
Handle invalid webhook JSON responses

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -291,7 +291,13 @@ def _post_rows_to_sheet(rows, sheet_name: str | None = None, sheet_gid: int | No
     if sheet_gid is not None:
         payload["sheet_gid"] = int(sheet_gid)
     r = requests.post(url, json=payload, timeout=20)
-    data = r.json() if r.headers.get("content-type", "").startswith("application/json") else {"ok": False, "error": r.text[:200]}
+    if r.headers.get("content-type", "").lower().startswith("application/json"):
+        try:
+            data = r.json()
+        except json.JSONDecodeError:
+            data = {"ok": False, "error": r.text[:200]}
+    else:
+        data = {"ok": False, "error": r.text[:200]}
     if r.status_code != 200 or not data.get("ok"):
         raise RuntimeError(f"Webhook error {r.status_code}: {data}")
     return data


### PR DESCRIPTION
## Summary
- Lower-case webhook `Content-Type` header and guard against invalid JSON responses.
- Preserve existing runtime error for unsuccessful webhook calls.

## Testing
- `python -m py_compile grammar.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1a388cad4832189f6f018fe7d5330