### PR TITLE
Validate reference sheet columns

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,6 +302,15 @@ refs_df = load_sheet_csv(
     gid=REF_TAB_GID,          # if provided, uses export endpoint (no truncation)
     cache_bust=cache_bust
 )
+# Expected columns: an "assignment" identifier column and at least one
+# answer column in the form "Answer1", "Answer2", etc.
+if (
+    "assignment" not in refs_df.columns
+    or not any(refs_df.columns.str.match(r"^Answer\d+$"))
+):
+    st.error("Reference sheet missing required columns")
+    st.stop()
+
 st.caption(f"Loaded reference tab: **{REF_TAB_NAME}** — {len(refs_df)} rows")
 
 # Ensure expected student columns exist / rename common variants


### PR DESCRIPTION
## Summary
- ensure reference sheet contains an `assignment` column and at least one `Answer` column
- halt and show an error if required reference columns are missing

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b41a93f2d0832190d2e4d37a9c7351