### PR TITLE
Handle reference answer columns case-insensitively

### DIFF
--- a/app.py
+++ b/app.py
@@ -314,7 +314,7 @@ refs_df = load_sheet_csv(
 # answer column in the form "Answer1", "Answer2", etc.
 if (
     "assignment" not in refs_df.columns
-    or not any(refs_df.columns.str.match(r"^Answer\d+$"))
+    or not any(refs_df.columns.str.match(r"^Answer\d+$", case=False))
 ):
     st.error("Reference sheet missing required columns")
     st.stop()


### PR DESCRIPTION
## Summary
- Allow detection of reference answer columns regardless of capitalization

## Testing
- `streamlit run app.py --server.headless true --server.port 8501`
- `python - <<'PY'
import pandas as pd
refs_df = pd.DataFrame(columns=['assignment', 'Answer1', 'Answer2'])
refs_df.columns = refs_df.columns.str.strip().str.lower()
print('Columns:', refs_df.columns.tolist())
print('Any matches:', any(refs_df.columns.str.match(r"^Answer\\d+$", case=False)))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b41eeaca90832187ec750a85eaca5e