### PR TITLE
Structure answers dictionary for AnswerN format

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -1,233 +1,844 @@
 {
-  "A1 Assignment 0.1\\t1. C) Guten Morgen\\t2. D) Guten Tag\\t3. B) Guten Abend\\t4. B) Gute Nacht\\t5. C) Guten Morgen\\t6. C) Wie geht es Ihnen\\t7. B) Auf Wiedersehen\\t8. A) Tschuss\\t9. C) Guten Abend\\t10. D) Gute Nacht\\t\\t": {
-    "answers": {}
-  },
-  "A1 Assignment 0.2\\t1. C) 26\\t2. A) A, O, U, B\\t3. A) Eszett\\t4. A) K\\t5. A) A-Umlaut\\t6. A) A, O, U, B\\t7. B 4\\t\\tWasser\\tKaffee\\tBlume\\tSchule\\tTisch\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 Assignment 1.1\\t1. C\\t2. C\\t3. A\\t4. B\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 Assignment 1.2\\t1. Ich heiße Anna\\t2. Du heißt Max\\t3. Er heißt Peter\\t4. Wir kommen aus Italien\\t\\t5. Ihr kommt aus Brasilien\\t6. Sie kommt/k kommen aus Russland\\t7. Ich wohne in Berlin\\t\\t8. Du wohnst in Madrid\\t9. Sie wohnt in Wien\\t\\t1. A) Anna\\t2. C) Aus Italien\\t3. D) In Berlin\\t4. B) Tom\\t5. A) In Berlin\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 Assignment 2\\t1. A) sieben\\t2. B) Drei\\t3. B) Sechs\\t4. B) Neun\\t5. B) Sieben\\t6. C) Fünf\\t\\t7. B) zweihundertzweiundzwanzig\\t8. A) fünfhundertneun\\t9. A) zweitausendvierzig\\t10. A) fünftausendfünfhundertneun\\t\\t1. 16 – sechzehn\\t2. 98 – achtundneunzig\\t3. 555 – fünfhundertfünfundfünfzig\\t\\t4. 1020 – tausendzwanzig\\t5. 8553 – achttausendfünfhundertdreiundfünfzig\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 Assignment 4\\t1. C) Neun\\t2. B) Polnisch\\t3. D) Niederländisch\\t4. A) Deutsch\\t5. C) Paris\\t6. B) Amsterdam\\t7. C) In der Schweiz\\t\\t1. C) In Italien und Frankreich\\t2. C) Rom\\t3. B) Das Essen\\t4. B) Paris\\t5. A) Nach Spanien\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 5\\tDer Tisch – the table\\tDie Lampe – the lamp\\tDas Buch – the book\\tDer Stuhl – the chair\\tDie Katze – the cat\\tDas Auto – the car\\tDer Hund – the dog\\tDie Blume – the flower\\tDas Fenster – the window\\tDer Computer – the computer\\t\\t1. Der Tisch ist groß\\t2. Die Lampe ist neu\\t3. Das Buch ist interessant\\t4. Der Stuhl ist bequem\\t5. Die Katze ist süß\\t6. Das Auto ist schnell\\t7. Der Hund ist freundlich\\t8. Die Blume ist schön\\t9. Das Fenster ist offen\\t10. Der Computer ist teuer\\t\\t1. Ich sehe den Tisch\\t2. Sie kauft die Lampe\\t3. Er liest das Buch\\t4. Wir brauchen den Stuhl\\t5. Du fütterst die Katze\\t6. Ich fahre das Auto\\t7. Sie streichelt den Hund\\t8. Er pflückt die Blume\\t9. Wir putzen das Fenster\\t10. Sie benutzen den Computer\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 6\\tDas Wohnzimmer – the living room\\tDie Küche – the kitchen\\tDas Schlafzimmer – the bedroom\\tDas Badezimmer – the bathroom\\tDer Balkon – the balcony\\t\\tDer Flur – the hallway\\tDas Bett – the bed\\tDer Tisch – the table\\tDer Stuhl – the chair\\tDer Schrank – the wardrobe\\t\\t1. B) Vier\\t2. A) Ein Sofa und ein Fernseher\\t3. B) Einen Herd, einen Kühlschrank und einen Tisch mit vier Stühlen\\t4. C) Ein großes Bett\\t5. D) Eine Dusche, eine Badewanne und ein Waschbecken\\t\\t6. B) Klein und schön\\t7. C) Blumen und einen kleinen Tisch mit zwei Stühlen\\t\\t1. B\\t2. B\\t3. B\\t4. C\\t5. D\\t6. B\\t7. C\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 7\\t1. B) Um sieben Uhr\\t2. B) Um acht Uhr\\t3. B) Um sechs Uhr\\t4. B) Um zehn Uhr\\t5. B) Um neun Uhr\\t\\t6. C) Nachmittags\\t7. B) Um sieben Uhr\\t8. A) Montag\\t9. B) Am Dienstag und Donnerstag\\t10. B) Er ruht sich aus\\t\\t1. B) Um Siehen Uhr\\t2. B) Um acht Uhr\\t3. B) Um Sechs Uhr\\t4. B) Um zehn Uhr\\t5. A) Sie geht zur Arbeit\\t\\t6. B) Um neun Uhr\\t7. B) Er geht in die Bibliothek\\t8. B) Bis zwei Uhr nachmittags\\t9. B) Um drei Uhr nachmittags\\t10. B) Um sieben Uhr\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 8\\t1. B) Zwei Uhr nachmittags\\t2. B) 29 Tage\\t3. B) April\\t4. C) 03.02.2024\\t5. C) Mittwoch\\t\\t1. Falsch\\t2. Richtig\\t3. Richtig\\t4. Falsch\\t5. Richtig\\t\\t1. B) Um Mitternacht\\t2. B) Vier Uhr nachmittags\\t3. C) 28 Tage\\t4. B) Tag. Monat. Jahr\\t5. D) Montag\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 9\\t1. B) Apfel und Karotten\\t2. C) Karotten\\t3. A) Weil er Vegetarier ist\\t4. C) Käse\\t5. B) Fleisch\\t\\t6. B) Kekse\\t7. A) Käse\\t8. C) Kuchen\\t9. C) Schokolade\\t10. B) Der Bruder des Autors\\t\\t1. A) Apfel, Bananen und Karotten\\t2. A) Müsli mit Joghurt\\t3. D) Karotten\\t4. A) Käse\\t5. C) Schokoladenkuchen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 10\\t1. Falsch\\t2. Wahr\\t3. Falsch\\t4. Wahr\\t5. Wahr\\t6. Falsch\\tWahr\\t7. Falsch\\t8. Falsch\\t9. Falsch\\t1. B) Einmal pro Woche\\t2. C) Apfel und Bananen\\t3. A) Ein halbes Kilo\\t4. B) 10 Euro\\t5. B) Einen schönen Tag\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 11\\t1. B) Entschuldigung, wo ist der Bahnhof?\\t2. B) Links abbiegen\\t3. B) Auf der rechten Seite, direkt neben dem großen Supermarkt\\t4. B) Wie komme ich zur nächsten Apotheke?\\t5. C) Gute Reise und einen schönen Tag noch\\t\\t1. C) Wie komme ich zur nächsten Apotheke?\\t2. C) Rechts abbiegen\\t3. B) Auf der linken Seite, direkt neben der Bäckerei\\t4. A) Gehen Sie geradeaus bis zur Kreuzung, dann links\\t5. C) Einen schönen Tag noch\\t\\t1. Fragen nach dem Weg: 'Entschuldigung, wie komme ich zum Bahnhof'\\t2. Die Straße überqueren: 'Überqueren Sie die Straße'\\t3. Geradeaus gehen: 'Gehen Sie geradeaus'\\t4. Links abbiegen: 'Biegen Sie links ab'\\t5. Rechts abbiegen: 'Biegen Sie rechts ab'\\t6. On the left side: 'Das Kino ist auf der linken Seite'\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 12.1\\t1. B) Ärztin\\t2. A) Weil sie keine Zeit hat\\t3. B) Um 8 Uhr\\t4. C) Viele verschiedene Fächer\\t5. C) Einen Sprachkurs besuchen\\t\\t1. Der Supermarkt ist nur am Wochenende geöffnet. Antwort: B) Falsch (Der Supermarkt hat jeden Tag von 8 Uhr bis 20 Uhr geöffnet.)\\t2. Die Theoriestunden sind jeden Tag. Antwort: B) Falsch (Die Theoriestunden finden dienstags und donnerstags statt.)\\t3. Das Büro ist auch am Wochenende geöffnet. Antwort: B) Falsch (Das Büro ist von Montag bis Freitag geöffnet.)\\t4. Der Englischkurs ist zweimal pro Woche. Antwort: B) Falsch (Der Englischkurs findet dreimal pro Woche statt.)\\t5. Das Fitnessstudio ist nur vormittags geöffnet. Antwort: B) Falsch (Das Fitnessstudio ist jeden Tag von 6 Uhr bis 22 Uhr geöffnet.)\\t\\t1. A) Richtig\\t2. A) Richtig\\t3. A) Richtig\\t4. A) Richtig\\t5. A) Richtig\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 12.2\\t1. In Berlin\\t2. Mit seiner Frau und seinen drei Kindern\\t3. Mit seinem Auto\\t4. Um 7:30 Uhr\\t5. a) Barzahlung (cash)\\t\\t1. B) Um 9:00 Uhr\\t2. B) Um 12:00 Uhr\\t3. B) Um 18:00 Uhr\\t4. B) Um 21:00 Uhr\\t5. D) Alles Genannte\\t\\t1. B) Um 9 Uhr\\t2. B) Um 12 Uhr\\t3. A) ein Computer und ein Drucker\\t4. C) in einer Bar\\t5. C) bar\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 13\\t1. A\\t2. B\\t3. A\\t4. A\\t5. B\\t6. B\\t\\t7. A\\t8. B\\t9. B\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A1 14.1\\tFrage 1: Anzeige A\\tFrage 2: Anzeige B\\tFrage 3: Anzeige B\\tFrage 4: Anzeige A\\tFrage 5: Anzeige A\\t1. a. Head – Kopf\\t2. b. Arm – Arm\\t3. c. Leg – Bein\\t4. d. Eye – Auge\\t5. e. Nose – Nase\\t6. f. Ear – Ohr\\t7. g. Mouth – Mund\\t8. h. Hand – Hand\\t9. i. Foot – Fuß\\t10. j. Stomach / Belly – Bauch\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 1.1 Small Talk\\t1. C) In einer Schule\\t2. B) Weil sie gerne mit Kindern arbeitet\\t3. A) In einem Buro\\t4. B) Tennis\\t5. B) Es war sonnig und warm\\t6. B) Italien und Spanien\\t7. C) Weil die Baume so schon bunt sind\\t\\t1. B) Ins Kino gehen\\t2. A) Weil sie spannende Geschichten liebt\\t3. A) Tennis\\t4. B) Es war sonnig und warm\\t5. C) Einen Spaziergang Machen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 1.2 Personen Beschreiben\\t1. B) Ein Jahr\\t2. B) Er ist immer gut gelaunt und organisiert\\t3. C) Einen Anzug und eine Brille\\t4. B) Er geht geduldig auf ihre Anliegen ein\\t5. B) Weil er seine Mitarbeiter regelmaBig lobt\\t6. A) Wenn eine Aufgabe nicht rechtzeitig erledigt wird\\t7. B) Dass er fair ist und die Leistungen der Mitarbeiter wertschatzt\\t\\t1. B) Weil er\\t2. C) Sprachkurse\\t3. A) Jeden tag\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 1.3 Dinge und Personen vergleichen\\t1. B) Anna ist 25 Jahre alt\\t2. B) In ihrer Freizeit liest Anna Bucher und geht spazieren\\t3. C) Anna arbeitet in einem Krankenhaus\\t4. C) Anna hat einen Hund\\t5. B) Max unterrichtet Mathematik\\t6. A) Max spielt oft FuBball mit seinen Freunden\\t7. B) Am Wochenende machen Anna und Max Ausfluge oder besuchen Museen\\t\\t1. B) Julia ist 26 Jahre alt\\t2. C) Julia arbeitet als Architektin\\t3. B) Tobias lebt in Frankfurt\\t4. A) Tobias mochte ein eigenes Restaurant eroffnen\\t5. B) Julia und Tobias kochen am Wochenende oft mit Sophie\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 2.4 Wo möchten wir uns treffen?\\t1. B) faul sein\\t2. d) Hockey spielen\\t3. a) schwimmen gehen\\t4. d) zum See fahren und dort im Zelt übernachten\\t5. b) eine Route mit dem Zug durch das ganze Land\\t\\t1. B) Um 10 Uhr\\t2. B) Eine Rucksack\\t3. B) Ein Piknik\\t4. C) in eienem restaurant\\t5. A) Spielen und Spazieren gehen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 2.5 Was machst du in deiner Freizeit\\t1. c) Nudeln, Pizza und Salat\\t2. c) Den grünen Salat\\t3. c) Schokoladenkuchen und Tiramisu\\t4. b) Die Suppe ist kalt\\t5. c) In bar\\t\\t1. A) Sie trinkt Tee\\t2. B) Mensch aregre\\t3. A) Sie geht jogeen\\t4. B) in den Bergen\\t5. B) Klassische Musik\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 3.6 Möbel und Räume kennenlernen\\t1. b) Weil ich studiere\\t2. b) Wenn es nicht regnet, stürmt oder schneit → Formuliert im Text als:\\t3. d) Es ist billig\\t4. d) Haustiere\\t5. c) Im Zoo\\t\\t1. A\\t2. A\\t3. B\\t4. B\\t5. B\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 3.7 Eine Wohnung suchen\\t1. b) In Zeitungen und im Internet\\t2. c) Eine Person, die bei der Wohnungssuche hilft\\t3. c) Kaltmiete und Nebenkosten\\t4. b) Ein Betrag, den man beim Auszug zurückbekommt\\t5. c) Ein Formular, das Schäden in der Wohnung zeigt\\t6. C) Von 22–7 Uhr und 13–15 Uhr\\t7. C) Zum Wertstoffcontainer bringen\\t\\t1. C) im dritten stock\\t2. B) 75 Quadratmeter\\t3. B) Drei\\t4. A) Ein balkon\\t5. B) 150 Euro\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 3.8 Rezepte und Essen\\t1. B) Brot, Brotchen, Aufschnitt, Kase und Marmelade\\t2. B) Ein Kaltes Abendessen\\t3. A) Fischgerichte\\t4. B) Oktoberfest\\t5. B) Gerichte aus aller Welt\\t6. C) Sauerkraut und Bratwurst\\t7. A) Eine zentrale Rolle\\t\\t1. B) Samstag\\t2. B) Obst und Gemuse\\t3. B) Mozzarella\\t4. B) Sie gehen in ein Café\\t5. A) Gemuselasagne\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 4.9 Urlaub\\t1. B) Musik hören, Bücher lesen, Filme sehen oder ausleihen\\t2. C) An der Volkshochschule\\t3. C) Sie treffen sich, weil sie gemeinsame Interessen haben.\\t4. C) Im botanischen Garten\\t5. B) Der Besuch von Parks und Spielplätzen\\t6. C) 17,98 Euro\\t7. C) In der Hausordnung\\t\\t1. B) Griechenland\\t2. A) Eine woche\\t3. B) Der strand von\\t4. B) Eine Bootstour\\t5. A) Nach Kreta zu reisen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 4.10 Tourismus und Traditionelle Feste\\t1. b) Die wichtigsten rechtlichen und politischen Regeln\\t2. c) Man muss Steuern zahlen\\t3. b) EU-Bürger dürfen bei Kommunalwahlen wählen\\t4. b) Er vertritt die Interessen von Migranten\\t5. a) Christlich-orthodox, jüdisch, islamisch, evangelisch, katholisch\\t6. b) Seit 1. Oktober 2017\\t7. c) Jeder darf seine Religion frei wählen und ausüben\\t\\t1. C) Munchen\\t2. B) Zwei Wochen\\t3. B) Brezeln, Bratwurst und Schweinebraten\\t4. B) Lederhosen und Dirndl\\t5. B) Fahrgeschafte und Spiele\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 4.11 Unterwegs: Verkehrsmittel vergleichen\\t1. b) In Italien\\t2. b) Weil sie in der Stadt fahren wird\\t3. a) Eine gute Versicherung\\t4. b) Führerschein und Personalausweis\\t5. b) Der Angestellte der Autovermietung\\t6. a) Viele Städte zu besuchen\\t7. b) Sehr zufrieden\\t\\t1. B) in die Berge\\t2. B) Ein Mittel..\\t3. B) 50 Euro\\t4. C) Führerschein und Kreditkarte\\t5. B) Das Auto auf mögliche\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 5.12 Ein Tag im Leben\\t1. C) Eine Behörde prüft, ob das Dokument echt ist\\t2. b) Auf der Internetseite „Anerkennung in Deutschland“\\t3. b) Die Zeitung\\t4. c) Berufsinformationszentrum\\t5. b) Ein Praktikum\\t6. c) Ein Kochrezept\\t7. c) Menschen unter 27 Jahren\\t\\t1. B) um 6 Uhr\\t2. C) Beginnt die Visite\\t3. B) um 9 Uhr\\t4. B) fuhrt wichtige\\t5. C) Vor 18 Uhr\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 5.13 Ein Vorstellungsgespräch\\t1. c) Ein Ort für kleine Kinder bis 3 Jahre\\t2. c) Ab 3 Jahren\\t3. d) Sie spielen, singen und basteln\\t4. d) Sie spielen, singen und basteln\\t5. c) Mittagessen\\t6. a) Reiche Familien\\t7. b) Es bekommt Hilfe beim Deutschlernen\\t\\t1. B) Um Interesse zu zeigen\\t2. B) Pünktlich sein\\t3. C) Um Interesse zu zeigen\\t4. A) Eine Dankes-E-Mail\\t5. B) Klar und deutlich sprechen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 5.14 Beruf und Karriere\\t1. B) Die Kollegen und die Arbeit\\t2. C) Mit „Sie“\\t3. C) Eine Arbeitnehmervertretung\\t4. C) Arbeitskleidung, Pausen und feste Arbeitszeiten\\t5. C) Man kann Arbeitsbeginn und -ende flexibel wählen\\t6. C) 38–40 Stunden\\t7. B) Den Urlaub eintragen und genehmigen lassen\\t8. D) Weiter das Gehalt oder den Lohn\\t9. C) Sofort den Arbeitgeber informieren und zum Arzt gehen\\t10. C) Auf der Baustelle oder am Flughafen\\t11. C) Die Kündigung schriftlich und mit Frist einreichen\\t12. C) In der Volkshochschule\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 6.15 Mein Lieblingssport\\t1. A) Yoga und Zumba\\t2. B) Fußball, Handball und Volleyball\\t3. C) Die Spenden an lokale Wohltätigkeitsorganisationen\\t4. B) Im Stadtpark\\t5. B) Fitnessprogramme\\t6. B) Die Eröffnung eines neuen Kletterparks\\t7. B) Eine wichtige Rolle zur Förderung der Lebensqualität\\t\\t1. B) Pilates- und Aerobic-Kurse\\t2. A) Kostenlose Yoga-Kurse\\t3. A) Wassergymnastik und Aqua-Zumba\\t4. C) Für Anfänger und Fortgeschrittene\\t5. B) Volleyball und Basketball\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 6.16 Wohlbefinden und Entspannung\\t1. C) Anzeige\\t2. B) Anzeige\\t3. E) Anzeige\\t4. F) Anzeige\\t5. A) Anzeige\\t\\t1. B) Mehr Obst und Gemüse essen\\t2. C) 30 Minuten\\t3. A) Der Besuch eines Fitnessstudios\\t4. B) Um Krankheiten frühzeitig zu erkennen\\t5. A) Yoga und Pilates\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 6.17 In die Apotheke gehen\\t1. B) Weil sie sich krank fühlte\\t2. B) Hustensaft\\t3. C) Hilfsbereit\\t4. B) Broschüren mit Tipps\\t5. C) Besser\\t6. B) Nach einigen Stunden\\t7. A) Sie kann sich auf den Rat der Apotheker verlassen\\t\\t1. B) Wegen Kopfschmerzen\\t2. C) Ibuprofen\\t3. B) Trockene Haut\\t4. B) Sie war erleichtert\\t5. B) Proben von Produkten\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 7.18 Die Bank Anrufen\\t1. B. Sparkasse\\t2. F. ING-DiBa\\t3. B. Sparkasse\\t4. D. Volksbank\\t5. C. Commerzbank\\t\\t1. B) Reisepass, Meldebescheinigung, Einkommensnachweis\\t2. B) Eine Stunde\\t3. B) Drei\\t4. A) Basiskonto\\t5. D) Die Formulare vor dem Termin online ausfüllen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 7.19 Einkaufen? Wo und wie?\\t1. B) Die Zunahme von Online-Shopping und Werbung\\t2. B) Wegen der ständigen Verfügbarkeit und einfachen Bestellung\\t3. B) Nachhaltiger Konsum\\t4. B) Weniger Plastik verwenden und lokale Produkte kaufen\\t5. B) Umweltverschmutzung und schlechte Arbeitsbedingungen\\t6. A) Sich gut informieren\\t7. B) Als komplexes Thema mit positiven und negativen Auswirkungen\\t\\t1. B) Bequeme Möglichkeit Produkte nach Hause zu bestellen\\t2. B) Hohe Anzahl von Rücksendungen und Umweltbelastung\\t3. A) Auf vertrauenswürdige Websites und Schutz persönlicher Daten\\t4. A) Aus nachhaltigen Quellen und fairen Bedingungen\\t5. B) Es hat den Konsum revolutioniert und neue Möglichkeiten geschaffen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 7.20 Typische Reklamationssituationen üben\\t1. C) Man sollte seine Qualifikationen und Erfahrungen erwähnen, weil sie die Eignung für die Stelle zeigen\\t2. A) Man sollte die Firma recherchieren, um gut informiert zu sein\\tB) Man sollte den Arbeitsweg üben, um pünktlich zu sein\\t3. A) Die Bezahlung, weil man finanziell abgesichert sein möchte\\tB) Die Arbeitszeiten, weil man eine gute Work-Life-Balance haben möchte\\t4. A) Frauen haben oft geringere Aufstiegschancen. Eine Lösung wäre eine Frauenquote.\\tB) Frauen verdienen häufig weniger als Männer. Transparente Gehaltsstrukturen könnten helfen.\\tC) Frauen müssen oft Beruf und Familie vereinbaren. Flexible Arbeitszeiten könnten eine Lösung sein.\\t5. A) Es gab weniger technische Geräte im Haushalt\\tB) Die Menschen waren weniger mobil und reisten seltener.\\tD) Die Arbeitszeiten waren länger und härter\\t\\t1. B) Die Berufliche\\t2. B) Man informiert sich\\t3. A) Die Bezahlung\\t4. A) Man sammelt\\t5. A) Geringere\\t6. A) Flexible Arbeitszeiten\\t7. A) Es gab weniger\\t8. B) Sie arbeiteten mehr und hatten weniger Freizeit\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 8.21 Ein Wochenende planen\\t1. C) Sollen Plätze reservieren\\t2. C) Nur ein Restaurant haben\\t3. C) Machte er eine lange Reise\\t4. A) Eine Fernsehsendung\\t5. A) Den Berufsweg eines Kochs\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 8.22 Die Woche Plannung\\t1. C) Im Moment ist vieles neu für sie.\\t2. B) Für neue Studenten eine Stadtführung gemacht.\\t3. C) Kocht jeder einmal für die anderen.\\t4. B) Deutsch zu sprechen.\\t5. C) Übernachtet Sonja in Marios Zimmer.\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 9.23 Wie kommst du zur Schule / zur Arbeit?\\t1. C) An die Nordsee\\t2. B) Auf einer Insel\\t3. A) Aus der Schweiz\\t4. A) Mit der U-Bahn\\t5. D) Die Berge und die Natur\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 9.24 Einen Urlaub planen\\t1. Anzeige: f\\t2. Anzeige: c\\t3. Anzeige: X\\t4. Anzeige: b\\t5. Anzeige: a\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 9.25 Tagesablauf\\t1. a) kurz vor 7 Uhr\\t2. d) Müsli oder Toast mit Marmelade\\t3. b) Hausaufgaben\\t4. a) am Nachmittag\\t5. b) Freunde treffen\\t6. c) die Schweiz\\t7. d) mit dem Zug\\t8. a) an einem kleinen Bahnhof\\t9. d) einen Zimmerschlüssel\\t10. b) das Zimmer ist zu klein\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 10.26 Gefühle in verschiedenen Situationen beschr\\t1. b) Er beantwortet Fragen und kontrolliert die Gesundheit des Kindes.\\t2. c) 14 Wochen\\t3. c) 14 Monate\\t4. a) Man muss einen festen Arbeitsvertrag haben.\\t5. a) Impfungen und Vorsorgeuntersuchungen\\t6. c) Ab 3 Jahren\\t7. b) An speziellen Freizeitangeboten in der Stadt teilnehmen\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 10.27 Digitale Kommunikation\\t1. b) Sie sind oft sehr teuer oder funktionieren nicht.\\t2. c) Ein deutsches Bankkonto und einen Ausweis.\\t3. C) 1 bis 2 Jahre\\t4. c) Drei Monate vor Vertragsende\\t5. c) In Supermärkten, Tankstellen oder Kiosken\\t6. b) Name, Adresse, Geburtsdatum und ein Ausweisdokument\\t7. d) Mit öffentlichem WLAN\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "A2 10.28 Über die Zukunft sprechen\\t1. c) Einen gültigen Reisepass\\t2. b) Bei der Deutschen Botschaft im Heimatland\\t3. c) Einen Aufenthaltstitel\\t4. b) Ein Kurs für Deutsch und Leben in Deutschland\\t5. c) Man muss sie übersetzen und anerkennen lassen\\t6. c) Die Arbeitsagentur\\t7. c) Kranken-, Renten- und Pflegeversicherung\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 1.1 Traumwelten\\t1. A) Dass sie von Gottern gesendet wurden\\t2. B) Sigmund Freud\\t3. A) Angst vor dem Alterwerden\\t4. B) Gemeinsames psychologisches Erbe der Menschheit\\t5. B) Als Gedachtnisverarbeitung\\t6. B) Universelle Symbole wie der Held oder die Mutter\\t7. B) Ein geheimnisvolles und faszinierendes Gebiet\\t1. A) Die Struktur des Benzolmolekuls\\t2. A) Die ldee fur “Frankenstein”\\t3. A) Angst und Unwohlsein\\t4. A) Wenn man im Traum bewusst ist, dass man traumt\\t5. A) In der REM-Phase\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 1.2 Freundes für Leben\\t1. B) Vertrauen\\t2. B) Emotional, finanziell oder praktisch\\t3. A) Sie schaffen gemeinsame Erlebnisse und Erinnerungen\\t4. A) Sie hilft, Missverstandnisse zu vermeiden\\t5. B) Den Fehler vergeben und hinter sich lassen\\t6. B) Er starkt die individuelle Freiheit\\t7. B) Vertrauen, Unterstutzung, Ehrlichkeit, Gemeinsame Interessen und Vergebung\\t1. A) Hort zu und gibt Rastschlage\\t2. A) Gemeinsame Erlebnisse und Erinnerungen\\t3. A) Sie vermeidet Missverstandnisse\\t4. B) Mit Freude\\t5. B) Fehler zu vergeben\\t6\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 1.3 Erfolgsgeschichten\\t1. A) Die Krankenschwester\\t2. B) Weil er fur seine Kinder kampft\\t3. C) Ihr Einsatz fur andere\\t4. B) Sie sind nicht beruhmt\\t5. B) Dass Mut in kleinen Taten liegt\\t6. B) Ein alleinerziehender Vater\\t7. B) Wahre Helden sind diejenigen, die im Alltag still wirken\\t1. B) Er beginnt seine Arbeit als Hausmeister\\t2. B) Weil sie den Schultag reibungslos macht\\t3. C) Die Heizung fallt aus\\t4. C) Er behebt da Problem, Sofort\\t5. A) Erschopft aber zufrieden\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 2.4 Wohnung suchen\\t1. B) Wegen des Mangels an bezahlbarem Wohnraum\\t2. A) Hohe Nachfrage nach Wahnungen\\t3. B) Um sie als Ferienwohnungen oder Luxusapartments zu nutzen\\t4. B) Einfuhrung der Mietpreisbremse und Neubauprogramme\\t5. A) Wegen der Nahe zu Schulen und Kindergarten\\t6. A) Geduld und Flexibilitat\\t7. B) Sie erfordert Zeit und Geduld\\t1. B) 950 Euro\\t2. C) 200 Euro\\t3. B) Nein\\t4. B) kleine Haustiere\\t5. B) Es gibt eine U-Bahn Station und mehree Bushaltestellen in der Nahe\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 2.5 Der Besichtigungsg termin\\t1. B) Am Samstag um 14:00 Uhr\\t2. B) Hell und geraumig\\t3. B) Die Badewanne\\t4. B) Zwei Monatsmieten\\t5. A) Ab dem ersten des nachsten Monats\\t6. B) Ein Jahr\\t7. C) Sie entschied sich, die Wohnung zu mieten\\t1. A) Am fruhen Morgen\\t2. B) Der Vermieter spart Zeit\\t3. B) Auf das Umfeld und die Nachbarschaft\\t4. C) Weil die Wohung schnell vergeben sein konnte\\t5. B) Gehaltsnachweise und Mieterselbstauskunft\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 2.6 Leben in der Stadt oder auf dem Land?\\t1. B) Einfamilienhaus\\t2. C) Balance zwischen Privatspare und Gemeinschaftsgefuhl\\t3. B) Weil sie gunstig sind\\t4. B) Ein Haus, das mit Solaranlagen ausgestattet ist\\t5. B) Sie spielt eine wichtige Rolle\\t6. B) Kurze Wege zu Geschaften und Restaurants\\t7. C) WG\\t1. B) Gemeinsame Nutzung von Haushaltsgeraten\\t2. B) Wegen der Privatsphare und des Plastzes\\t3. C) Wohnungen in Mehrfamilienhausern\\t4. C) Passivhauser\\t5. B) Mischung aus Privatsphare und sozialer interaktion\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 3.7 Fast Food vs. Hausmannskost\\t1. A) Sie konnen zu Ubergewicht und Diabetes fuhren\\t2. B) Sie konnen positive Gefuhle auslosen\\t3. B) Zucker schadet den Zahnen\\t4. B) Sie konnen langfristig gesundheitliche Probleme verursachen\\t5. B) Karies und Ubergewicht\\t6. C) Man sollte den Zukerkonsum reduzieren und auf eine ausgewogene Ernahrung achten\\t7. A) Durch korperliche Aktivitat und Entspannungstechniken\\t1. F) Veranstaltung uber gesunde Ernahrung und Zuckerreduktion\\t2. B) Werbung fur ein neues Diat – Programm\\t3. C) Angebot fur zuckerfreie SuBigkeiten\\t4. D) Eroffnung eines neuen Restuarants mit gesunden Gerichten\\t5. E) Rabbatt auf Schokolade im Onlne-Shop\\t1. B) In vielen Fertiggerichten und Softdrinks\\t2. B) Er gibt uns Kurzzeitig Energie\\t3. A) Man fuhlt sich energielos und mude\\t4. A) Erhohtes Risiko fur Ubergewicht und Diabetes Typ 2\\t5. B) Den Zuckerkonsum zu reduzieren und mehr frische Lebensmittel zu essen\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 3.8 Alles für die Gesundheit\\t1. A) Jemand, der jeden Tag Menschenleben rettet\\t2. B) Er sagt, er macht nur seinen Job\\t3. B) Weil ihre Taten oft unsichtbar sind\\t4. C) Der Druck, schnell die richtige Entscheidung zu treffen\\t5. B) Ihr Engagement fur die Gesellschaft\\t6. C) Jemand, der Engagement zeigt\\t7. C) Sie leisten wichtige Beitrage, die oft unsichtber sind\\t1. B) Er sorgt fur die Patienten und bereitet ihre Bedurfnisse vor\\t2. A) Er sieht sie als eine Pflicht an die Menschheit\\t3. B) Er ist immer ruhig und findet Losungen\\t4. C) Er bietet emotionale Unterstutzung und hort zu\\t5. B) Sie sehen ihn als einen stillen Helden\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 3.9. Work-Life-Balance im modernen Arbeitsumfeld\\t1. B) Zeitdruck und hohe Erwartungen\\t2. C) Herzprobleme und Bluthochdruck\\t3. A) RegelmaBige Bewegung\\t4. B) Sie liefert dem korper die notigen Nahrstoffe\\t5. C) Den Korper und Geist zu entspannen\\t6. B) Sie tragen zum Wohlbefinden bei\\t7. B) Auf die Signale des korpers horen fruhzeitig MaBnahmen ergreifen\\t1. B) Realistische Ziele setzen\\t2. C) Sie verbessert die Stimmun\\t3. A) Sie beruhigen Korper und Geist\\t4. B) Weil er den kpoper\\t5.B ;Sie helfen, das wohibefinden zu steigern": {
-    "answers": {}
-  },
-  "B1 4.10 Digitale Auszeit und Selbstfürsorge\\t1. B) Die Wichtigkeit von Zeit fur sich\\t2. B) Menschen, die regelmaBig Pausen Machen, sind weniger gestresst und produktiver\\t3. B) Einsamkeit und Isolation\\t4. A) Sie hiflt, das Risiko von Herz-Kreislauf-Erkrankungen zu senken\\t5. B) Man fuhit sich oft gelangweilt und prokrastiniert\\t6. C) Man sollte eine ausgewogene Balance zwischen Zeit fur sich und sozialen Kontakten finden\\t7. B) Indem man Aktivitaten plant, die einem SpaB machen und guttun\\t1. C) Stress und Uberarbeitung\\t2. B) Produktiver\\t3. A) Sie verbessert die Kommunikation und Geduld\\t4. B) Sie haben weniger Schlafprobleme und Ruckenschmerzen\\t5. C) Gefuhle der Einsamkeit und Isolation\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 4.11 Teamspiele und Kooperative Aktivitäten\\t1. C) Spiele im Freien\\t2. B) Sie fordern strategisches Denken\\t3. C) Es kann zu Sucht fuhren\\t4. B) Soziale Fahigkeiten\\t5. B) Verlust der sozialen Fahigkeiten\\t6. C) Eine Balance zwischen digitalem und traditionellem Spielen finden\\t7. A) Minecraft\\t1. A) Um stress abzubauen\\t2. B) Brettspiele\\t3. B) Sie fordern soziale und korpeliche Fahigkeiten\\t4. B) Digitale Spiele\\t5. A) Traditionelle Spiele Haben Soziale und Korperliche Vorteile\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 4.12 Abenteuer in der Natur\\t1. A\\t2. B\\t3. B\\t4. B\\t5. B\\t6. B\\t7. B\\t1. A\\t2. A\\t3. A\\t4. B\\t5. B\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 4.13 Eigene Filmkritik schreiben\\t1. A) Ein mysterioser Mod\\t2. C) Er ist ein Ermittler\\t3. C) Eine nachtliche Verfolgung\\t4. D) Eine unerwartete Figur\\t5. C) Spannungssteigernd\\t6. B) Die Dialoge waren klischeehaft\\t7. A) Ja\\t1. B) Spannung\\t2. B) Ein leises, schleichendes Gerausch\\t3. B) Durch schnelle Schnitte und Nahaufnahmen\\t4. C) Die Ungewissheit uber den Verlauf der Handlung\\t5. C) Weil sie Abenteuer ohne echte Gefahr erleben wollen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 5.14 Traditionelles vs. digitales Lernen\\t1. B) Der Arbeitsmarkt verandert sich schnell\\t2. A) Es ist billiger als formelles Lernen\\t3. B) ESUMMER30s halt den Deist jung und aktiv\\t4. A) Die Kosten fur Kurse\\t5. A) Technologie macht Lernen einfacher und zuganglicher\\t6. B) Kreativitat und Anpassungsfahigkeit\\t7. C) Die richtige Einstellung und Disziplin\\t1. A) Sie mochte in ihrem Beruf vorankommen\\t2. A) Programmierung\\t3. B) Sie haben wenig Zeit\\t4. A) Er nimmt sich jeden Tag eine Stunde Zeit\\t5. C) RegelmaBig und in kleinen Schritten lernen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 5.15 Medien und Arbeiten im Homeoffice\\t1. B) Sie ermoglicht eine bessere Kommunikation und flexible Arbeiten\\t2. C) Stress und Soziale Isolation\\t3. B) Als leicht gefahrdet\\t4. A) Die altere Generation\\t5. B) Die Kontrolle uber den technologischen Fortschritt\\t6. B) Bessere digitale Bilding\\t7. A) Uberwaltigt\\t1. C) Flexibilitat durch Homeoffice\\t2. B) Mehr stress und weniger Trennung von Arbeit und Privatleben\\t3. A) Wegen technischer Ungleichheiten\\t4. C) Gesundheitliche Probleme\\t5. C) Balance zwischen digitalem und realem Leben finden\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 5.16 Prüfungsangst und Stressbewältigung\\t1. B) Prufungen fordern das Kurzzeitgedachtnis\\t2. C) Schriftliche, mundliche und praktische Prufungen\\t3. B) Prufungsstress\\t4. B) Projekte und Hausarbeiten\\t5. B) Mundliche Prufungen\\t6. B) Enstspannungstechniken und gute Vorbereitung\\t7. B) Sie sind fairer und individueller\\t1. B) RegelmaBiges Lernen und Pausen machen\\t2. A) Meditation und positives Denken\\t3. C) Es kann helfan, die Angst zu reduzieren\\t4. B) Sich klarzumachen, dass die Prufung nur eine Momentaufnahme ist\\t5. C) Negative Gedanken und Stress\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 5.17 Wie lernt man am besten?\\t1. B) Aktives Arbeiten mit dem lernstoff, z.B. durch Zusammenfassungen\\t2. C) Sachlaf hilft, das Gelernte zu speichern\\t3. B) RegelmaBige Pausen\\t4. B) Das regelmaBige Wiederholen des Lernstoffs\\t5. A) Durch aktives Lernen und Wiederholung\\t6. C) Spaced repetition\\t7. B) Sei bringen Struktur in den Lernprozess\\t1. A) Der Lernstof wird in Kleinere Abschnitte aufgeteilt\\t2. B) Es hilft, den Stoff dauerhaft zu behalten\\t3. B) Eine ruhige und aufgeraumte Umgebund\\t4. B) Indem man sich selbst Fragen zum Gelernten stellt\\t5. B) Sich selbst belohnen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 6.18 Wege zum Wunschberuf\\t1. C) Leidenschaft und Vernunft\\t2. B) Flexibilitat und Weiterbildung\\t3. C) Eine Mischung aus Leidenschaft und Vernunft finden\\t4. B) Der Traumberuf ist nicht immer gefragt\\t5. C) Die realen Bedingungen auf dem Arbeitsmarkt\\t6. C) Sie sind nur kurzfristig gefragt\\t7. A) Durch Flexibilitat und Bereitschaft zur Weiterbildung\\t1. B) SpaB an der Arbeit\\t2. C) Um Einblicke in das Berufsfeld zu erhalten\\t3. A) Ob es genug Stellen im Beruf gibt\\t4. B) Zwischen Wunsch und Realitat\\t5. C) Flexibel sein und sich anpassen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 6.19 Das Vorstellungsgespräch\\t1. B) die umweltfreundliche Stromproduktion in Feldheim\\t2. a) ein ganzes Dorf von modernen Energien leben kann\\t3. C) muss die Bevölkerung dafür sein\\t4. B) es ein neues Tourismus-Angebot gibt\\t5. B) muss man nicht sportlich sein\\t6. C) mehr Velo-Touristen in die Region kommen\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 6.20 Wie wird man ?? (Ausbildung und Qu)\\t1. A) Richtig\\t2. B) Falsch\\t3. B) Falsch\\t4. B) Falsch\\t5. A) Richtig\\t6. B) Falsch\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 7.21 Lebensformen heute ? Familie, Wohnge\\t1. B) Sie wollte Auslandserfahrung sammeln\\t2. B) Sie wollte Auslandserfahrung sammeln\\t3. D) Ja, zwei Söhne.\\t4. D) Ja, fünf Geschwister\\t5. C) Weil ihre Eltern dort wohnen\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 7.22 Was ist dir in einer Beziehung wichtig?\\t1. D) 500 Jahre\\t2. B) Alexanderplatz\\t3. D) Eine Einkaufsstraße\\t4. D) in einem Hotel\\t5. C) Stadtrundfahrten\\t1. D) im Supermarkt\\t2. B) Name, Alter, Wohnort\\t3. D) Zeugnisse und Anschreiben\\t4. A) Man lernt den Arbeitgeber kennen.\\t5.C) Man kann sich bei der nächsten offenen Stelle bewerben.\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 7.23 Erstes Date ? Typische Situationen\\t1. C) Elizabeth Magie Phillips\\t2. B) The Landlord’s Game\\t3. B) Wie unfair Monopole sind\\t4. C) Er gab es als seine eigene Idee aus\\t5. D) So gut wie nichts\\t6. B) Weil Parker Brothers es verkaufte\\t\\t7. B) Mary Pilon\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 8.24 Konsum und Nachhaltigkeit\\t1. False\\t2. True\\t3. False\\t4. False\\t5. True\\t\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 8.25 Online einkaufen ? Rechte und Risiken\\t1. B) Sie ist selbstständig und verdient mehr\\t2. C) Weil der Service und die Beratung gut sind\\t3. B) Sie trennt Müll und spart Energie\\t4. c) Die Familie stellt die Heizung auf 18 Grad und schaltet Geräte aus\\t5. B) Beratung zu Konsum, Verträgen und Ernährung\\t6. c) Durch den Staat und Kundenzahlungen\\t7. B) Broschüren mit Informationen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 9.26 Reiseprobleme und Lösungen\\t1. B) Mecklenburg-Vorpommern\\t\\t3. B) Rügen und Usedom\\t4. B) Städte wie Berlin, Hamburg, Köln und München\\t5. B) Das Oktoberfest\\t6. B) Neuschwanstein, Herrenchiemsee und Linderhof\\t7. C) Weil das Wetter in Deutschland nicht immer sonnig und warm ist\\t\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 10.27 Umweltfreundlich im Alltag\\t1. C) Papier, Glas und Plastik\\t2. A) Durch den Einsatz energieeffizienter Gerate\\t3. A) Durch den Einsatz energieeffizienter Gerate\\t4. A) Fahrrader und offentliche Verkehrsmittel\\t5. B) Weil die Fleischproduktion ressourcenintensiv ist\\t6. C) Umweltfreundlich einkaufen\\t7. C) Umweltfreundlich einkaufen\\t\\t1. B) Stoffbeutel\\t2. B) Indem man Produkte ohne Plastikverpackung kauft\\t3. C) Indem man das Licht ausschaltet, wenn man einen Raum verlasst\\t4. B) Die Heizung niedriger stellen und warme Kleidung tragen\\t5. B) Bei jedem Einzelnen\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "B1 10.28 Klimafreundlich leben\\t1. B\\t2. B\\t3. B\\t4. B\\t5. A\\t6. B\\t7. B\\t1. B\\t2. B\\t3. B\\t4. B\\t5. B\\t\\t\\t\\t\\t\\t": {
-    "answers": {}
-  },
-  "C1 1\\t1. b) Die frühzeitige Erkennung von Krankheiten.\\t2. a) Datenschutz und Verantwortung.\\t3. b) Genforschung.\\t4. b) Die Heilung von genetischen Krankheiten.\\t5. b) Sie bietet sowohl Chancen als auch Risiken.\\t6. b) Sie muss die Entwicklungen kritisch hinterfragen.\\t7. b) Wegen der möglichen Auswirkungen auf zukünftige Generationen.\\t1. b) Die Effizienz erneuerbarer Energien zu verbessern\\t2. b) Solar- und Windkraft.\\t3. b) Die Industrie.\\t4. b) Unterstützung von Politik und Wirtschaft.\\t5": {
-    "answers": {}
-  },
-  "B2 1\\t1. B) Persönliche Identität und Selbstverständnis in der modernen Gesellschaft\\t2. B) Ein Zusammenspiel zwischen innerem Selbstverständnis und äußeren Einflüssen\\t3. B) In der Jugend\\t4. B) Es bietet eine Plattform, sich zu präsentieren und zu hinterfragen\\t5. C) Viele finden ihre wahre Identität nicht\\t6. B) Sich regelmäßig reflektieren und Veränderungen zulassen\\t7. B) Flexibilität\\t1. B) Wegen eines Unfalls\\t2. C) Bis zum Mittag\\t3.B) Schwierigkeiten für Familien mit geringem Einkommen\\t4. B) Es wird sonnig\\t5. C) Es gibt Zugausfälle und längere Fahrzeiten": {
-    "answers": {}
-  },
-  "B2 1.2\\t1. B) Weil Online-Kommunikation oft oberflächlich ist\\t2. C) Missverständnisse entstehen leichter.\\t3. B) Das Handy kann zur Entfremdung führen.\\t3. C) Sie kann in Fernbeziehungen helfen.\\t4. C) Ehrlichkeit, Zuhören und Empathie\\t5. B) Viele denken während des Gesprächs an etwas anderes.\\t6. C) Es kann zu Problemen in der Partnerschaft führen.\\t1. B) Sie verspüren manchmal Einsamkeit.\\t2. C) Missverständnisse entstehen, weil Mimik und Tonfall fehlen.\\t3. B) Um Distanzen zu überbrücken.\\t4. B) Probleme, wenn sich jemand vernachlässigt fühlt\\t5. C) Ehrlich reden und aufmerksam zuhören": {
-    "answers": {}
-  },
-  "B2 1.4 - Beruf und Karriere\\t1. B) Globalisierung, Digitalisierung, demografischer Wandel\\t2. B) Es ist ein zentraler Erfolgsfaktor\\t3. B) Weniger Pendelzeit und flexiblere Arbeitsgestaltung\\t4. b) Fehlender direkter Kontakt zu Kollegen\\t5. C) Work-Life-Balance und persönliche Entwicklung\\t6. A) Sie ist der Schlüssel zu beruflichem und persönlichem Erfolg\\t7. B) Sich aktiv mit Trends auseinandersetzen\\t1. B) Fachliche Qualifikationen und Soft Skills\\t2. B) Authentizität und gute Vorbereitung\\t3. B) Sie kennen die Firmenkultur\\t4. B) Fachkräftemangel\\t5. C) Menschen auf ihrem beruflichen Weg zu begleiten": {
-    "answers": {}
+  "A1 Assignment 0.1": {
+    "answers": {
+      "Answer1": "C) Guten Morgen",
+      "Answer2": "D) Guten Tag",
+      "Answer3": "B) Guten Abend",
+      "Answer4": "B) Gute Nacht",
+      "Answer5": "C) Guten Morgen",
+      "Answer6": "C) Wie geht es Ihnen",
+      "Answer7": "B) Auf Wiedersehen",
+      "Answer8": "A) Tschuss",
+      "Answer9": "C) Guten Abend",
+      "Answer10": "D) Gute Nacht"
+    }
+  },
+  "A1 Assignment 0.2": {
+    "answers": {
+      "Answer1": "C) 26",
+      "Answer2": "A) A, O, U, B",
+      "Answer3": "A) Eszett",
+      "Answer4": "A) K",
+      "Answer5": "A) A-Umlaut",
+      "Answer6": "A) A, O, U, B",
+      "Answer7": "B 4 Wasser Kaffee Blume Schule Tisch"
+    }
+  },
+  "A1 Assignment 1.1": {
+    "answers": {
+      "Answer1": "C",
+      "Answer2": "C",
+      "Answer3": "A",
+      "Answer4": "B"
+    }
+  },
+  "A1 Assignment 1.2": {
+    "answers": {
+      "Answer1": "A) Anna",
+      "Answer2": "C) Aus Italien",
+      "Answer3": "D) In Berlin",
+      "Answer4": "B) Tom",
+      "Answer5": "A) In Berlin",
+      "Answer6": "Sie kommt/k kommen aus Russland",
+      "Answer7": "Ich wohne in Berlin",
+      "Answer8": "Du wohnst in Madrid",
+      "Answer9": "Sie wohnt in Wien"
+    }
+  },
+  "A1 Assignment 2": {
+    "answers": {
+      "Answer1": "16 – sechzehn",
+      "Answer2": "98 – achtundneunzig",
+      "Answer3": "555 – fünfhundertfünfundfünfzig",
+      "Answer4": "1020 – tausendzwanzig",
+      "Answer5": "8553 – achttausendfünfhundertdreiundfünfzig",
+      "Answer6": "C) Fünf",
+      "Answer7": "B) zweihundertzweiundzwanzig",
+      "Answer8": "A) fünfhundertneun",
+      "Answer9": "A) zweitausendvierzig",
+      "Answer10": "A) fünftausendfünfhundertneun"
+    }
+  },
+  "A1 Assignment 4": {
+    "answers": {
+      "Answer1": "C) In Italien und Frankreich",
+      "Answer2": "C) Rom",
+      "Answer3": "B) Das Essen",
+      "Answer4": "B) Paris",
+      "Answer5": "A) Nach Spanien",
+      "Answer6": "B) Amsterdam",
+      "Answer7": "C) In der Schweiz"
+    }
+  },
+  "A1 5": {
+    "answers": {
+      "Answer1": "Ich sehe den Tisch",
+      "Answer2": "Sie kauft die Lampe",
+      "Answer3": "Er liest das Buch",
+      "Answer4": "Wir brauchen den Stuhl",
+      "Answer5": "Du fütterst die Katze",
+      "Answer6": "Ich fahre das Auto",
+      "Answer7": "Sie streichelt den Hund",
+      "Answer8": "Er pflückt die Blume",
+      "Answer9": "Wir putzen das Fenster",
+      "Answer10": "Sie benutzen den Computer"
+    }
+  },
+  "A1 6": {
+    "answers": {
+      "Answer1": "B",
+      "Answer2": "B",
+      "Answer3": "B",
+      "Answer4": "C",
+      "Answer5": "D",
+      "Answer6": "B",
+      "Answer7": "C"
+    }
+  },
+  "A1 7": {
+    "answers": {
+      "Answer1": "B) Um Siehen Uhr",
+      "Answer2": "B) Um acht Uhr",
+      "Answer3": "B) Um Sechs Uhr",
+      "Answer4": "B) Um zehn Uhr",
+      "Answer5": "A) Sie geht zur Arbeit",
+      "Answer6": "B) Um neun Uhr",
+      "Answer7": "B) Er geht in die Bibliothek",
+      "Answer8": "B) Bis zwei Uhr nachmittags",
+      "Answer9": "B) Um drei Uhr nachmittags",
+      "Answer10": "B) Um sieben Uhr"
+    }
+  },
+  "A1 8": {
+    "answers": {
+      "Answer1": "B) Um Mitternacht",
+      "Answer2": "B) Vier Uhr nachmittags",
+      "Answer3": "C) 28 Tage",
+      "Answer4": "B) Tag. Monat. Jahr",
+      "Answer5": "D) Montag"
+    }
+  },
+  "A1 9": {
+    "answers": {
+      "Answer1": "A) Apfel, Bananen und Karotten",
+      "Answer2": "A) Müsli mit Joghurt",
+      "Answer3": "D) Karotten",
+      "Answer4": "A) Käse",
+      "Answer5": "C) Schokoladenkuchen",
+      "Answer6": "B) Kekse",
+      "Answer7": "A) Käse",
+      "Answer8": "C) Kuchen",
+      "Answer9": "C) Schokolade",
+      "Answer10": "B) Der Bruder des Autors"
+    }
+  },
+  "A1 10": {
+    "answers": {
+      "Answer1": "B) Einmal pro Woche",
+      "Answer2": "C) Apfel und Bananen",
+      "Answer3": "A) Ein halbes Kilo",
+      "Answer4": "B) 10 Euro",
+      "Answer5": "B) Einen schönen Tag",
+      "Answer6": "Falsch Wahr",
+      "Answer7": "Falsch",
+      "Answer8": "Falsch",
+      "Answer9": "Falsch"
+    }
+  },
+  "A1 11": {
+    "answers": {
+      "Answer1": "Fragen nach dem Weg: 'Entschuldigung, wie komme ich zum Bahnhof'",
+      "Answer2": "Die Straße überqueren: 'Überqueren Sie die Straße'",
+      "Answer3": "Geradeaus gehen: 'Gehen Sie geradeaus'",
+      "Answer4": "Links abbiegen: 'Biegen Sie links ab'",
+      "Answer5": "Rechts abbiegen: 'Biegen Sie rechts ab'",
+      "Answer6": "On the left side: 'Das Kino ist auf der linken Seite'"
+    }
+  },
+  "A1 12.1": {
+    "answers": {
+      "Answer1": "A) Richtig",
+      "Answer2": "A) Richtig",
+      "Answer3": "A) Richtig",
+      "Answer4": "A) Richtig",
+      "Answer5": "A) Richtig"
+    }
+  },
+  "A1 12.2": {
+    "answers": {
+      "Answer1": "B) Um 9 Uhr",
+      "Answer2": "B) Um 12 Uhr",
+      "Answer3": "A) ein Computer und ein Drucker",
+      "Answer4": "C) in einer Bar",
+      "Answer5": "C) bar"
+    }
+  },
+  "A1 13": {
+    "answers": {
+      "Answer1": "A",
+      "Answer2": "B",
+      "Answer3": "A",
+      "Answer4": "A",
+      "Answer5": "B",
+      "Answer6": "B",
+      "Answer7": "A",
+      "Answer8": "B",
+      "Answer9": "B"
+    }
+  },
+  "A1 14.1": {
+    "answers": {
+      "Answer1": "a. Head – Kopf",
+      "Answer2": "b. Arm – Arm",
+      "Answer3": "c. Leg – Bein",
+      "Answer4": "d. Eye – Auge",
+      "Answer5": "e. Nose – Nase",
+      "Answer6": "f. Ear – Ohr",
+      "Answer7": "g. Mouth – Mund",
+      "Answer8": "h. Hand – Hand",
+      "Answer9": "i. Foot – Fuß",
+      "Answer10": "j. Stomach / Belly – Bauch"
+    }
+  },
+  "A2 1.1 Small Talk": {
+    "answers": {
+      "Answer1": "B) Ins Kino gehen",
+      "Answer2": "A) Weil sie spannende Geschichten liebt",
+      "Answer3": "A) Tennis",
+      "Answer4": "B) Es war sonnig und warm",
+      "Answer5": "C) Einen Spaziergang Machen",
+      "Answer6": "B) Italien und Spanien",
+      "Answer7": "C) Weil die Baume so schon bunt sind"
+    }
+  },
+  "A2 1.2 Personen Beschreiben": {
+    "answers": {
+      "Answer1": "B) Weil er",
+      "Answer2": "C) Sprachkurse",
+      "Answer3": "A) Jeden tag",
+      "Answer4": "B) Er geht geduldig auf ihre Anliegen ein",
+      "Answer5": "B) Weil er seine Mitarbeiter regelmaBig lobt",
+      "Answer6": "A) Wenn eine Aufgabe nicht rechtzeitig erledigt wird",
+      "Answer7": "B) Dass er fair ist und die Leistungen der Mitarbeiter wertschatzt"
+    }
+  },
+  "A2 1.3 Dinge und Personen vergleichen": {
+    "answers": {
+      "Answer1": "B) Julia ist 26 Jahre alt",
+      "Answer2": "C) Julia arbeitet als Architektin",
+      "Answer3": "B) Tobias lebt in Frankfurt",
+      "Answer4": "A) Tobias mochte ein eigenes Restaurant eroffnen",
+      "Answer5": "B) Julia und Tobias kochen am Wochenende oft mit Sophie",
+      "Answer6": "A) Max spielt oft FuBball mit seinen Freunden",
+      "Answer7": "B) Am Wochenende machen Anna und Max Ausfluge oder besuchen Museen"
+    }
+  },
+  "A2 2.4 Wo möchten wir uns treffen?": {
+    "answers": {
+      "Answer1": "B) Um 10 Uhr",
+      "Answer2": "B) Eine Rucksack",
+      "Answer3": "B) Ein Piknik",
+      "Answer4": "C) in eienem restaurant",
+      "Answer5": "A) Spielen und Spazieren gehen"
+    }
+  },
+  "A2 2.5 Was machst du in deiner Freizeit": {
+    "answers": {
+      "Answer1": "A) Sie trinkt Tee",
+      "Answer2": "B) Mensch aregre",
+      "Answer3": "A) Sie geht jogeen",
+      "Answer4": "B) in den Bergen",
+      "Answer5": "B) Klassische Musik"
+    }
+  },
+  "A2 3.6 Möbel und Räume kennenlernen": {
+    "answers": {
+      "Answer1": "A",
+      "Answer2": "A",
+      "Answer3": "B",
+      "Answer4": "B",
+      "Answer5": "B"
+    }
+  },
+  "A2 3.7 Eine Wohnung suchen": {
+    "answers": {
+      "Answer1": "C) im dritten stock",
+      "Answer2": "B) 75 Quadratmeter",
+      "Answer3": "B) Drei",
+      "Answer4": "A) Ein balkon",
+      "Answer5": "B) 150 Euro",
+      "Answer6": "C) Von 22–7 Uhr und 13–15 Uhr",
+      "Answer7": "C) Zum Wertstoffcontainer bringen"
+    }
+  },
+  "A2 3.8 Rezepte und Essen": {
+    "answers": {
+      "Answer1": "B) Samstag",
+      "Answer2": "B) Obst und Gemuse",
+      "Answer3": "B) Mozzarella",
+      "Answer4": "B) Sie gehen in ein Café",
+      "Answer5": "A) Gemuselasagne",
+      "Answer6": "C) Sauerkraut und Bratwurst",
+      "Answer7": "A) Eine zentrale Rolle"
+    }
+  },
+  "A2 4.9 Urlaub": {
+    "answers": {
+      "Answer1": "B) Griechenland",
+      "Answer2": "A) Eine woche",
+      "Answer3": "B) Der strand von",
+      "Answer4": "B) Eine Bootstour",
+      "Answer5": "A) Nach Kreta zu reisen",
+      "Answer6": "C) 17,98 Euro",
+      "Answer7": "C) In der Hausordnung"
+    }
+  },
+  "A2 4.10 Tourismus und Traditionelle Feste": {
+    "answers": {
+      "Answer1": "C) Munchen",
+      "Answer2": "B) Zwei Wochen",
+      "Answer3": "B) Brezeln, Bratwurst und Schweinebraten",
+      "Answer4": "B) Lederhosen und Dirndl",
+      "Answer5": "B) Fahrgeschafte und Spiele",
+      "Answer6": "b) Seit 1. Oktober 2017",
+      "Answer7": "c) Jeder darf seine Religion frei wählen und ausüben"
+    }
+  },
+  "A2 4.11 Unterwegs: Verkehrsmittel vergleichen": {
+    "answers": {
+      "Answer1": "B) in die Berge",
+      "Answer2": "B) Ein Mittel..",
+      "Answer3": "B) 50 Euro",
+      "Answer4": "C) Führerschein und Kreditkarte",
+      "Answer5": "B) Das Auto auf mögliche",
+      "Answer6": "a) Viele Städte zu besuchen",
+      "Answer7": "b) Sehr zufrieden"
+    }
+  },
+  "A2 5.12 Ein Tag im Leben": {
+    "answers": {
+      "Answer1": "B) um 6 Uhr",
+      "Answer2": "C) Beginnt die Visite",
+      "Answer3": "B) um 9 Uhr",
+      "Answer4": "B) fuhrt wichtige",
+      "Answer5": "C) Vor 18 Uhr",
+      "Answer6": "c) Ein Kochrezept",
+      "Answer7": "c) Menschen unter 27 Jahren"
+    }
+  },
+  "A2 5.13 Ein Vorstellungsgespräch": {
+    "answers": {
+      "Answer1": "B) Um Interesse zu zeigen",
+      "Answer2": "B) Pünktlich sein",
+      "Answer3": "C) Um Interesse zu zeigen",
+      "Answer4": "A) Eine Dankes-E-Mail",
+      "Answer5": "B) Klar und deutlich sprechen",
+      "Answer6": "a) Reiche Familien",
+      "Answer7": "b) Es bekommt Hilfe beim Deutschlernen"
+    }
+  },
+  "A2 5.14 Beruf und Karriere": {
+    "answers": {
+      "Answer1": "B) Die Kollegen und die Arbeit",
+      "Answer2": "C) Mit „Sie“",
+      "Answer3": "C) Eine Arbeitnehmervertretung",
+      "Answer4": "C) Arbeitskleidung, Pausen und feste Arbeitszeiten",
+      "Answer5": "C) Man kann Arbeitsbeginn und -ende flexibel wählen",
+      "Answer6": "C) 38–40 Stunden",
+      "Answer7": "B) Den Urlaub eintragen und genehmigen lassen",
+      "Answer8": "D) Weiter das Gehalt oder den Lohn",
+      "Answer9": "C) Sofort den Arbeitgeber informieren und zum Arzt gehen",
+      "Answer10": "C) Auf der Baustelle oder am Flughafen",
+      "Answer11": "C) Die Kündigung schriftlich und mit Frist einreichen",
+      "Answer12": "C) In der Volkshochschule"
+    }
+  },
+  "A2 6.15 Mein Lieblingssport": {
+    "answers": {
+      "Answer1": "B) Pilates- und Aerobic-Kurse",
+      "Answer2": "A) Kostenlose Yoga-Kurse",
+      "Answer3": "A) Wassergymnastik und Aqua-Zumba",
+      "Answer4": "C) Für Anfänger und Fortgeschrittene",
+      "Answer5": "B) Volleyball und Basketball",
+      "Answer6": "B) Die Eröffnung eines neuen Kletterparks",
+      "Answer7": "B) Eine wichtige Rolle zur Förderung der Lebensqualität"
+    }
+  },
+  "A2 6.16 Wohlbefinden und Entspannung": {
+    "answers": {
+      "Answer1": "B) Mehr Obst und Gemüse essen",
+      "Answer2": "C) 30 Minuten",
+      "Answer3": "A) Der Besuch eines Fitnessstudios",
+      "Answer4": "B) Um Krankheiten frühzeitig zu erkennen",
+      "Answer5": "A) Yoga und Pilates"
+    }
+  },
+  "A2 6.17 In die Apotheke gehen": {
+    "answers": {
+      "Answer1": "B) Wegen Kopfschmerzen",
+      "Answer2": "C) Ibuprofen",
+      "Answer3": "B) Trockene Haut",
+      "Answer4": "B) Sie war erleichtert",
+      "Answer5": "B) Proben von Produkten",
+      "Answer6": "B) Nach einigen Stunden",
+      "Answer7": "A) Sie kann sich auf den Rat der Apotheker verlassen"
+    }
+  },
+  "A2 7.18 Die Bank Anrufen": {
+    "answers": {
+      "Answer1": "B) Reisepass, Meldebescheinigung, Einkommensnachweis",
+      "Answer2": "B) Eine Stunde",
+      "Answer3": "B) Drei",
+      "Answer4": "A) Basiskonto",
+      "Answer5": "D) Die Formulare vor dem Termin online ausfüllen"
+    }
+  },
+  "A2 7.19 Einkaufen? Wo und wie?": {
+    "answers": {
+      "Answer1": "B) Bequeme Möglichkeit Produkte nach Hause zu bestellen",
+      "Answer2": "B) Hohe Anzahl von Rücksendungen und Umweltbelastung",
+      "Answer3": "A) Auf vertrauenswürdige Websites und Schutz persönlicher Daten",
+      "Answer4": "A) Aus nachhaltigen Quellen und fairen Bedingungen",
+      "Answer5": "B) Es hat den Konsum revolutioniert und neue Möglichkeiten geschaffen",
+      "Answer6": "A) Sich gut informieren",
+      "Answer7": "B) Als komplexes Thema mit positiven und negativen Auswirkungen"
+    }
+  },
+  "A2 7.20 Typische Reklamationssituationen üben": {
+    "answers": {
+      "Answer1": "B) Die Berufliche",
+      "Answer2": "B) Man informiert sich",
+      "Answer3": "A) Die Bezahlung",
+      "Answer4": "A) Man sammelt",
+      "Answer5": "A) Geringere",
+      "Answer6": "A) Flexible Arbeitszeiten",
+      "Answer7": "A) Es gab weniger",
+      "Answer8": "B) Sie arbeiteten mehr und hatten weniger Freizeit"
+    }
+  },
+  "A2 8.21 Ein Wochenende planen": {
+    "answers": {
+      "Answer1": "C) Sollen Plätze reservieren",
+      "Answer2": "C) Nur ein Restaurant haben",
+      "Answer3": "C) Machte er eine lange Reise",
+      "Answer4": "A) Eine Fernsehsendung",
+      "Answer5": "A) Den Berufsweg eines Kochs"
+    }
+  },
+  "A2 8.22 Die Woche Plannung": {
+    "answers": {
+      "Answer1": "C) Im Moment ist vieles neu für sie.",
+      "Answer2": "B) Für neue Studenten eine Stadtführung gemacht.",
+      "Answer3": "C) Kocht jeder einmal für die anderen.",
+      "Answer4": "B) Deutsch zu sprechen.",
+      "Answer5": "C) Übernachtet Sonja in Marios Zimmer."
+    }
+  },
+  "A2 9.23 Wie kommst du zur Schule / zur Arbeit?": {
+    "answers": {
+      "Answer1": "C) An die Nordsee",
+      "Answer2": "B) Auf einer Insel",
+      "Answer3": "A) Aus der Schweiz",
+      "Answer4": "A) Mit der U-Bahn",
+      "Answer5": "D) Die Berge und die Natur"
+    }
+  },
+  "A2 9.24 Einen Urlaub planen": {
+    "answers": {
+      "Answer1": "Anzeige: f",
+      "Answer2": "Anzeige: c",
+      "Answer3": "Anzeige: X",
+      "Answer4": "Anzeige: b",
+      "Answer5": "Anzeige: a"
+    }
+  },
+  "A2 9.25 Tagesablauf": {
+    "answers": {
+      "Answer1": "a) kurz vor 7 Uhr",
+      "Answer2": "d) Müsli oder Toast mit Marmelade",
+      "Answer3": "b) Hausaufgaben",
+      "Answer4": "a) am Nachmittag",
+      "Answer5": "b) Freunde treffen",
+      "Answer6": "c) die Schweiz",
+      "Answer7": "d) mit dem Zug",
+      "Answer8": "a) an einem kleinen Bahnhof",
+      "Answer9": "d) einen Zimmerschlüssel",
+      "Answer10": "b) das Zimmer ist zu klein"
+    }
+  },
+  "A2 10.26 Gefühle in verschiedenen Situationen beschr": {
+    "answers": {
+      "Answer1": "b) Er beantwortet Fragen und kontrolliert die Gesundheit des Kindes.",
+      "Answer2": "c) 14 Wochen",
+      "Answer3": "c) 14 Monate",
+      "Answer4": "a) Man muss einen festen Arbeitsvertrag haben.",
+      "Answer5": "a) Impfungen und Vorsorgeuntersuchungen",
+      "Answer6": "c) Ab 3 Jahren",
+      "Answer7": "b) An speziellen Freizeitangeboten in der Stadt teilnehmen"
+    }
+  },
+  "A2 10.27 Digitale Kommunikation": {
+    "answers": {
+      "Answer1": "b) Sie sind oft sehr teuer oder funktionieren nicht.",
+      "Answer2": "c) Ein deutsches Bankkonto und einen Ausweis.",
+      "Answer3": "C) 1 bis 2 Jahre",
+      "Answer4": "c) Drei Monate vor Vertragsende",
+      "Answer5": "c) In Supermärkten, Tankstellen oder Kiosken",
+      "Answer6": "b) Name, Adresse, Geburtsdatum und ein Ausweisdokument",
+      "Answer7": "d) Mit öffentlichem WLAN"
+    }
+  },
+  "A2 10.28 Über die Zukunft sprechen": {
+    "answers": {
+      "Answer1": "c) Einen gültigen Reisepass",
+      "Answer2": "b) Bei der Deutschen Botschaft im Heimatland",
+      "Answer3": "c) Einen Aufenthaltstitel",
+      "Answer4": "b) Ein Kurs für Deutsch und Leben in Deutschland",
+      "Answer5": "c) Man muss sie übersetzen und anerkennen lassen",
+      "Answer6": "c) Die Arbeitsagentur",
+      "Answer7": "c) Kranken-, Renten- und Pflegeversicherung"
+    }
+  },
+  "B1 1.1 Traumwelten": {
+    "answers": {
+      "Answer1": "A) Die Struktur des Benzolmolekuls",
+      "Answer2": "A) Die ldee fur “Frankenstein”",
+      "Answer3": "A) Angst und Unwohlsein",
+      "Answer4": "A) Wenn man im Traum bewusst ist, dass man traumt",
+      "Answer5": "A) In der REM-Phase",
+      "Answer6": "B) Universelle Symbole wie der Held oder die Mutter",
+      "Answer7": "B) Ein geheimnisvolles und faszinierendes Gebiet"
+    }
+  },
+  "B1 1.2 Freundes für Leben": {
+    "answers": {
+      "Answer1": "A) Hort zu und gibt Rastschlage",
+      "Answer2": "A) Gemeinsame Erlebnisse und Erinnerungen",
+      "Answer3": "A) Sie vermeidet Missverstandnisse",
+      "Answer4": "B) Mit Freude",
+      "Answer5": "B) Fehler zu vergeben 6",
+      "Answer6": "B) Er starkt die individuelle Freiheit",
+      "Answer7": "B) Vertrauen, Unterstutzung, Ehrlichkeit, Gemeinsame Interessen und Vergebung"
+    }
+  },
+  "B1 1.3 Erfolgsgeschichten": {
+    "answers": {
+      "Answer1": "B) Er beginnt seine Arbeit als Hausmeister",
+      "Answer2": "B) Weil sie den Schultag reibungslos macht",
+      "Answer3": "C) Die Heizung fallt aus",
+      "Answer4": "C) Er behebt da Problem, Sofort",
+      "Answer5": "A) Erschopft aber zufrieden",
+      "Answer6": "B) Ein alleinerziehender Vater",
+      "Answer7": "B) Wahre Helden sind diejenigen, die im Alltag still wirken"
+    }
+  },
+  "B1 2.4 Wohnung suchen": {
+    "answers": {
+      "Answer1": "B) 950 Euro",
+      "Answer2": "C) 200 Euro",
+      "Answer3": "B) Nein",
+      "Answer4": "B) kleine Haustiere",
+      "Answer5": "B) Es gibt eine U-Bahn Station und mehree Bushaltestellen in der Nahe",
+      "Answer6": "A) Geduld und Flexibilitat",
+      "Answer7": "B) Sie erfordert Zeit und Geduld"
+    }
+  },
+  "B1 2.5 Der Besichtigungsg termin": {
+    "answers": {
+      "Answer1": "A) Am fruhen Morgen",
+      "Answer2": "B) Der Vermieter spart Zeit",
+      "Answer3": "B) Auf das Umfeld und die Nachbarschaft",
+      "Answer4": "C) Weil die Wohung schnell vergeben sein konnte",
+      "Answer5": "B) Gehaltsnachweise und Mieterselbstauskunft",
+      "Answer6": "B) Ein Jahr",
+      "Answer7": "C) Sie entschied sich, die Wohnung zu mieten"
+    }
+  },
+  "B1 2.6 Leben in der Stadt oder auf dem Land?": {
+    "answers": {
+      "Answer1": "B) Gemeinsame Nutzung von Haushaltsgeraten",
+      "Answer2": "B) Wegen der Privatsphare und des Plastzes",
+      "Answer3": "C) Wohnungen in Mehrfamilienhausern",
+      "Answer4": "C) Passivhauser",
+      "Answer5": "B) Mischung aus Privatsphare und sozialer interaktion",
+      "Answer6": "B) Kurze Wege zu Geschaften und Restaurants",
+      "Answer7": "C) WG"
+    }
+  },
+  "B1 3.7 Fast Food vs. Hausmannskost": {
+    "answers": {
+      "Answer1": "B) In vielen Fertiggerichten und Softdrinks",
+      "Answer2": "B) Er gibt uns Kurzzeitig Energie",
+      "Answer3": "A) Man fuhlt sich energielos und mude",
+      "Answer4": "A) Erhohtes Risiko fur Ubergewicht und Diabetes Typ 2",
+      "Answer5": "B) Den Zuckerkonsum zu reduzieren und mehr frische Lebensmittel zu essen",
+      "Answer6": "C) Man sollte den Zukerkonsum reduzieren und auf eine ausgewogene Ernahrung achten",
+      "Answer7": "A) Durch korperliche Aktivitat und Entspannungstechniken"
+    }
+  },
+  "B1 3.8 Alles für die Gesundheit": {
+    "answers": {
+      "Answer1": "B) Er sorgt fur die Patienten und bereitet ihre Bedurfnisse vor",
+      "Answer2": "A) Er sieht sie als eine Pflicht an die Menschheit",
+      "Answer3": "B) Er ist immer ruhig und findet Losungen",
+      "Answer4": "C) Er bietet emotionale Unterstutzung und hort zu",
+      "Answer5": "B) Sie sehen ihn als einen stillen Helden",
+      "Answer6": "C) Jemand, der Engagement zeigt",
+      "Answer7": "C) Sie leisten wichtige Beitrage, die oft unsichtber sind"
+    }
+  },
+  "B1 3.9. Work-Life-Balance im modernen Arbeitsumfeld": {
+    "answers": {
+      "Answer1": "B) Realistische Ziele setzen",
+      "Answer2": "C) Sie verbessert die Stimmun",
+      "Answer3": "A) Sie beruhigen Korper und Geist",
+      "Answer4": "B) Weil er den kpoper",
+      "Answer5": "B ;Sie helfen, das wohibefinden zu steigern",
+      "Answer6": "B) Sie tragen zum Wohlbefinden bei",
+      "Answer7": "B) Auf die Signale des korpers horen fruhzeitig MaBnahmen ergreifen"
+    }
+  },
+  "B1 4.10 Digitale Auszeit und Selbstfürsorge": {
+    "answers": {
+      "Answer1": "C) Stress und Uberarbeitung",
+      "Answer2": "B) Produktiver",
+      "Answer3": "A) Sie verbessert die Kommunikation und Geduld",
+      "Answer4": "B) Sie haben weniger Schlafprobleme und Ruckenschmerzen",
+      "Answer5": "C) Gefuhle der Einsamkeit und Isolation",
+      "Answer6": "C) Man sollte eine ausgewogene Balance zwischen Zeit fur sich und sozialen Kontakten finden",
+      "Answer7": "B) Indem man Aktivitaten plant, die einem SpaB machen und guttun"
+    }
+  },
+  "B1 4.11 Teamspiele und Kooperative Aktivitäten": {
+    "answers": {
+      "Answer1": "A) Um stress abzubauen",
+      "Answer2": "B) Brettspiele",
+      "Answer3": "B) Sie fordern soziale und korpeliche Fahigkeiten",
+      "Answer4": "B) Digitale Spiele",
+      "Answer5": "A) Traditionelle Spiele Haben Soziale und Korperliche Vorteile",
+      "Answer6": "C) Eine Balance zwischen digitalem und traditionellem Spielen finden",
+      "Answer7": "A) Minecraft"
+    }
+  },
+  "B1 4.12 Abenteuer in der Natur": {
+    "answers": {
+      "Answer1": "A",
+      "Answer2": "A",
+      "Answer3": "A",
+      "Answer4": "B",
+      "Answer5": "B",
+      "Answer6": "B",
+      "Answer7": "B"
+    }
+  },
+  "B1 4.13 Eigene Filmkritik schreiben": {
+    "answers": {
+      "Answer1": "B) Spannung",
+      "Answer2": "B) Ein leises, schleichendes Gerausch",
+      "Answer3": "B) Durch schnelle Schnitte und Nahaufnahmen",
+      "Answer4": "C) Die Ungewissheit uber den Verlauf der Handlung",
+      "Answer5": "C) Weil sie Abenteuer ohne echte Gefahr erleben wollen",
+      "Answer6": "B) Die Dialoge waren klischeehaft",
+      "Answer7": "A) Ja"
+    }
+  },
+  "B1 5.14 Traditionelles vs. digitales Lernen": {
+    "answers": {
+      "Answer1": "A) Sie mochte in ihrem Beruf vorankommen",
+      "Answer2": "A) Programmierung",
+      "Answer3": "B) Sie haben wenig Zeit",
+      "Answer4": "A) Er nimmt sich jeden Tag eine Stunde Zeit",
+      "Answer5": "C) RegelmaBig und in kleinen Schritten lernen",
+      "Answer6": "B) Kreativitat und Anpassungsfahigkeit",
+      "Answer7": "C) Die richtige Einstellung und Disziplin"
+    }
+  },
+  "B1 5.15 Medien und Arbeiten im Homeoffice": {
+    "answers": {
+      "Answer1": "C) Flexibilitat durch Homeoffice",
+      "Answer2": "B) Mehr stress und weniger Trennung von Arbeit und Privatleben",
+      "Answer3": "A) Wegen technischer Ungleichheiten",
+      "Answer4": "C) Gesundheitliche Probleme",
+      "Answer5": "C) Balance zwischen digitalem und realem Leben finden",
+      "Answer6": "B) Bessere digitale Bilding",
+      "Answer7": "A) Uberwaltigt"
+    }
+  },
+  "B1 5.16 Prüfungsangst und Stressbewältigung": {
+    "answers": {
+      "Answer1": "B) RegelmaBiges Lernen und Pausen machen",
+      "Answer2": "A) Meditation und positives Denken",
+      "Answer3": "C) Es kann helfan, die Angst zu reduzieren",
+      "Answer4": "B) Sich klarzumachen, dass die Prufung nur eine Momentaufnahme ist",
+      "Answer5": "C) Negative Gedanken und Stress",
+      "Answer6": "B) Enstspannungstechniken und gute Vorbereitung",
+      "Answer7": "B) Sie sind fairer und individueller"
+    }
+  },
+  "B1 5.17 Wie lernt man am besten?": {
+    "answers": {
+      "Answer1": "A) Der Lernstof wird in Kleinere Abschnitte aufgeteilt",
+      "Answer2": "B) Es hilft, den Stoff dauerhaft zu behalten",
+      "Answer3": "B) Eine ruhige und aufgeraumte Umgebund",
+      "Answer4": "B) Indem man sich selbst Fragen zum Gelernten stellt",
+      "Answer5": "B) Sich selbst belohnen",
+      "Answer6": "C) Spaced repetition",
+      "Answer7": "B) Sei bringen Struktur in den Lernprozess"
+    }
+  },
+  "B1 6.18 Wege zum Wunschberuf": {
+    "answers": {
+      "Answer1": "B) SpaB an der Arbeit",
+      "Answer2": "C) Um Einblicke in das Berufsfeld zu erhalten",
+      "Answer3": "A) Ob es genug Stellen im Beruf gibt",
+      "Answer4": "B) Zwischen Wunsch und Realitat",
+      "Answer5": "C) Flexibel sein und sich anpassen",
+      "Answer6": "C) Sie sind nur kurzfristig gefragt",
+      "Answer7": "A) Durch Flexibilitat und Bereitschaft zur Weiterbildung"
+    }
+  },
+  "B1 6.19 Das Vorstellungsgespräch": {
+    "answers": {
+      "Answer1": "B) die umweltfreundliche Stromproduktion in Feldheim",
+      "Answer2": "a) ein ganzes Dorf von modernen Energien leben kann",
+      "Answer3": "C) muss die Bevölkerung dafür sein",
+      "Answer4": "B) es ein neues Tourismus-Angebot gibt",
+      "Answer5": "B) muss man nicht sportlich sein",
+      "Answer6": "C) mehr Velo-Touristen in die Region kommen"
+    }
+  },
+  "B1 6.20 Wie wird man ?? (Ausbildung und Qu)": {
+    "answers": {
+      "Answer1": "A) Richtig",
+      "Answer2": "B) Falsch",
+      "Answer3": "B) Falsch",
+      "Answer4": "B) Falsch",
+      "Answer5": "A) Richtig",
+      "Answer6": "B) Falsch"
+    }
+  },
+  "B1 7.21 Lebensformen heute ? Familie, Wohnge": {
+    "answers": {
+      "Answer1": "B) Sie wollte Auslandserfahrung sammeln",
+      "Answer2": "B) Sie wollte Auslandserfahrung sammeln",
+      "Answer3": "D) Ja, zwei Söhne.",
+      "Answer4": "D) Ja, fünf Geschwister",
+      "Answer5": "C) Weil ihre Eltern dort wohnen"
+    }
+  },
+  "B1 7.22 Was ist dir in einer Beziehung wichtig?": {
+    "answers": {
+      "Answer1": "D) im Supermarkt",
+      "Answer2": "B) Name, Alter, Wohnort",
+      "Answer3": "D) Zeugnisse und Anschreiben",
+      "Answer4": "A) Man lernt den Arbeitgeber kennen.",
+      "Answer5": "C) Man kann sich bei der nächsten offenen Stelle bewerben."
+    }
+  },
+  "B1 7.23 Erstes Date ? Typische Situationen": {
+    "answers": {
+      "Answer1": "C) Elizabeth Magie Phillips",
+      "Answer2": "B) The Landlord’s Game",
+      "Answer3": "B) Wie unfair Monopole sind",
+      "Answer4": "C) Er gab es als seine eigene Idee aus",
+      "Answer5": "D) So gut wie nichts",
+      "Answer6": "B) Weil Parker Brothers es verkaufte",
+      "Answer7": "B) Mary Pilon"
+    }
+  },
+  "B1 8.24 Konsum und Nachhaltigkeit": {
+    "answers": {
+      "Answer1": "False",
+      "Answer2": "True",
+      "Answer3": "False",
+      "Answer4": "False",
+      "Answer5": "True"
+    }
+  },
+  "B1 8.25 Online einkaufen ? Rechte und Risiken": {
+    "answers": {
+      "Answer1": "B) Sie ist selbstständig und verdient mehr",
+      "Answer2": "C) Weil der Service und die Beratung gut sind",
+      "Answer3": "B) Sie trennt Müll und spart Energie",
+      "Answer4": "c) Die Familie stellt die Heizung auf 18 Grad und schaltet Geräte aus",
+      "Answer5": "B) Beratung zu Konsum, Verträgen und Ernährung",
+      "Answer6": "c) Durch den Staat und Kundenzahlungen",
+      "Answer7": "B) Broschüren mit Informationen"
+    }
+  },
+  "B1 9.26 Reiseprobleme und Lösungen": {
+    "answers": {
+      "Answer1": "B) Mecklenburg-Vorpommern",
+      "Answer3": "B) Rügen und Usedom",
+      "Answer4": "B) Städte wie Berlin, Hamburg, Köln und München",
+      "Answer5": "B) Das Oktoberfest",
+      "Answer6": "B) Neuschwanstein, Herrenchiemsee und Linderhof",
+      "Answer7": "C) Weil das Wetter in Deutschland nicht immer sonnig und warm ist"
+    }
+  },
+  "B1 10.27 Umweltfreundlich im Alltag": {
+    "answers": {
+      "Answer1": "B) Stoffbeutel",
+      "Answer2": "B) Indem man Produkte ohne Plastikverpackung kauft",
+      "Answer3": "C) Indem man das Licht ausschaltet, wenn man einen Raum verlasst",
+      "Answer4": "B) Die Heizung niedriger stellen und warme Kleidung tragen",
+      "Answer5": "B) Bei jedem Einzelnen",
+      "Answer6": "C) Umweltfreundlich einkaufen",
+      "Answer7": "C) Umweltfreundlich einkaufen"
+    }
+  },
+  "B1 10.28 Klimafreundlich leben": {
+    "answers": {
+      "Answer1": "B",
+      "Answer2": "B",
+      "Answer3": "B",
+      "Answer4": "B",
+      "Answer5": "B",
+      "Answer6": "B",
+      "Answer7": "B"
+    }
+  },
+  "C1 1": {
+    "answers": {
+      "Answer1": "b) Die Effizienz erneuerbarer Energien zu verbessern",
+      "Answer2": "b) Solar- und Windkraft.",
+      "Answer3": "b) Die Industrie.",
+      "Answer4": "b) Unterstützung von Politik und Wirtschaft. 5",
+      "Answer5": "b) Sie bietet sowohl Chancen als auch Risiken.",
+      "Answer6": "b) Sie muss die Entwicklungen kritisch hinterfragen.",
+      "Answer7": "b) Wegen der möglichen Auswirkungen auf zukünftige Generationen."
+    }
+  },
+  "B2 1": {
+    "answers": {
+      "Answer1": "B) Wegen eines Unfalls",
+      "Answer2": "C) Bis zum Mittag",
+      "Answer3": "B) Schwierigkeiten für Familien mit geringem Einkommen",
+      "Answer4": "B) Es wird sonnig",
+      "Answer5": "C) Es gibt Zugausfälle und längere Fahrzeiten",
+      "Answer6": "B) Sich regelmäßig reflektieren und Veränderungen zulassen",
+      "Answer7": "B) Flexibilität"
+    }
+  },
+  "B2 1.2": {
+    "answers": {
+      "Answer1": "B) Sie verspüren manchmal Einsamkeit.",
+      "Answer2": "C) Missverständnisse entstehen, weil Mimik und Tonfall fehlen.",
+      "Answer3": "B) Um Distanzen zu überbrücken.",
+      "Answer4": "B) Probleme, wenn sich jemand vernachlässigt fühlt",
+      "Answer5": "C) Ehrlich reden und aufmerksam zuhören",
+      "Answer6": "C) Es kann zu Problemen in der Partnerschaft führen."
+    }
+  },
+  "B2 1.4 - Beruf und Karriere": {
+    "answers": {
+      "Answer1": "B) Fachliche Qualifikationen und Soft Skills",
+      "Answer2": "B) Authentizität und gute Vorbereitung",
+      "Answer3": "B) Sie kennen die Firmenkultur",
+      "Answer4": "B) Fachkräftemangel",
+      "Answer5": "C) Menschen auf ihrem beruflichen Weg zu begleiten",
+      "Answer6": "A) Sie ist der Schlüssel zu beruflichem und persönlichem Erfolg",
+      "Answer7": "B) Sich aktiv mit Trends auseinandersetzen"
+    }
   }
 }

--- a/app.py
+++ b/app.py
@@ -74,7 +74,14 @@ def load_answers_dictionary() -> Dict[str, Any]:
     for p in ANSWERS_JSON_PATHS:
         if os.path.exists(p):
             with open(p, "r", encoding="utf-8") as f:
-                return json.load(f)
+                data = json.load(f)
+            # ensure every entry has an "answers" dict (Answer1, Answer2, ...)
+            for k, v in data.items():
+                if not isinstance(v, dict):
+                    data[k] = {"answers": {}}
+                elif "answers" not in v:
+                    v["answers"] = {}
+            return data
     st.error("❌ answers_dictionary.json not found in the repo.")
     return {}
 
@@ -92,7 +99,10 @@ def build_reference_text(row_obj: Dict[str, Any]) -> Tuple[str, str]:
     def n_from_key(k: str) -> int:
         m = re.search(r"(\d+)", k)
         return int(m.group(1)) if m else 0
-    ordered = [k for k in sorted(answers.keys(), key=n_from_key)]
+    ordered = [
+        k for k in sorted(answers.keys(), key=n_from_key)
+        if k.lower().startswith("answer")
+    ]
     chunks = []
     for k in ordered:
         v = str(answers[k]).strip()


### PR DESCRIPTION
## Summary
- Restructure `answers_dictionary.json` to store reference answers under `Answer1`, `Answer2`, etc.
- Normalize loading so every entry exposes an `answers` map and only AnswerN keys are used when building reference text.

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'\nimport json\nwith open('answers_dictionary.json','r',encoding='utf-8') as f:\n    data=json.load(f)\nprint('assignments', len(data))\nfirst_key=next(iter(data))\nprint('first', first_key, 'answers', list(data[first_key]['answers'].keys())[:3])\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68b4237f539883219dab2d7807490846