### PR TITLE
Improve AI marking prompt with detailed feedback and umlaut guidance

### DIFF
--- a/app.py
+++ b/app.py
@@ -177,7 +177,9 @@ def ai_mark(student_answer: str, ref_text: str) -> Tuple[int | None, str]:
 You are a German teacher. Compare the student's answer with the reference answer.
 Return STRICT JSON with:
 - score: integer 0-100
-- feedback: ~40 words, constructive.
+- feedback: constructive. List major errors and briefly justify the numeric score.
+  If the student's text lacks umlauts (ä, ö, ü, ß), remind them that holding "s",
+  "u", or "o" produces them, but do not deduct points for this omission.
 
 Student answer:
 {student_answer}


### PR DESCRIPTION
## Summary
- Expand AI prompt to list major errors, justify scores, and advise on umlaut entry without penalizing omissions.
- Remove 40-word limit on feedback while retaining JSON `score` and `feedback` structure.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b426b1705c8321bccf8f47347cba74