### PR TITLE
Normalize A1 assignment keys

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -76,7 +76,7 @@
     },
     "answer_url": "https://example.com/reference/A1%20Assignment%204"
   },
-  "A1 5": {
+  "A1 Assignment 5": {
     "answers": {
       "Answer1": "Ich sehe den Tisch",
       "Answer2": "Sie kauft die Lampe",
@@ -91,7 +91,7 @@
     },
     "answer_url": "https://example.com/reference/A1%205"
   },
-  "A1 6": {
+  "A1 Assignment 6": {
     "answers": {
       "Answer1": "B",
       "Answer2": "B",
@@ -103,7 +103,7 @@
     },
     "answer_url": "https://example.com/reference/A1%206"
   },
-  "A1 7": {
+  "A1 Assignment 7": {
     "answers": {
       "Answer1": "B) Um Siehen Uhr",
       "Answer2": "B) Um acht Uhr",
@@ -118,7 +118,7 @@
     },
     "answer_url": "https://example.com/reference/A1%207"
   },
-  "A1 8": {
+  "A1 Assignment 8": {
     "answers": {
       "Answer1": "B) Um Mitternacht",
       "Answer2": "B) Vier Uhr nachmittags",
@@ -128,7 +128,7 @@
     },
     "answer_url": "https://example.com/reference/A1%208"
   },
-  "A1 9": {
+  "A1 Assignment 9": {
     "answers": {
       "Answer1": "A) Apfel, Bananen und Karotten",
       "Answer2": "A) Müsli mit Joghurt",
@@ -143,7 +143,7 @@
     },
     "answer_url": "https://example.com/reference/A1%209"
   },
-  "A1 10": {
+  "A1 Assignment 10": {
     "answers": {
       "Answer1": "B) Einmal pro Woche",
       "Answer2": "C) Apfel und Bananen",
@@ -157,7 +157,7 @@
     },
     "answer_url": "https://example.com/reference/A1%2010"
   },
-  "A1 11": {
+  "A1 Assignment 11": {
     "answers": {
       "Answer1": "Fragen nach dem Weg: 'Entschuldigung, wie komme ich zum Bahnhof'",
       "Answer2": "Die Straße überqueren: 'Überqueren Sie die Straße'",
@@ -168,7 +168,7 @@
     },
     "answer_url": "https://example.com/reference/A1%2011"
   },
-  "A1 12.1": {
+  "A1 Assignment 12.1": {
     "answers": {
       "Answer1": "A) Richtig",
       "Answer2": "A) Richtig",
@@ -178,7 +178,7 @@
     },
     "answer_url": "https://example.com/reference/A1%2012.1"
   },
-  "A1 12.2": {
+  "A1 Assignment 12.2": {
     "answers": {
       "Answer1": "B) Um 9 Uhr",
       "Answer2": "B) Um 12 Uhr",
@@ -188,7 +188,7 @@
     },
     "answer_url": "https://example.com/reference/A1%2012.2"
   },
-  "A1 13": {
+  "A1 Assignment 13": {
     "answers": {
       "Answer1": "A",
       "Answer2": "B",
@@ -202,7 +202,7 @@
     },
     "answer_url": "https://example.com/reference/A1%2013"
   },
-  "A1 14.1": {
+  "A1 Assignment 14.1": {
     "answers": {
       "Answer1": "a. Head – Kopf",
       "Answer2": "b. Arm – Arm",

--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ ANSWERS_JSON_PATHS = [
 # Utilities
 # =========================================================
 def natural_key(s: str):
-    """Natural sort key: 'A1 10' after 'A1 2'."""
+    """Natural sort key: 'A1 Assignment 10' after 'A1 Assignment 2'."""
     return [int(t) if t.isdigit() else t.lower() for t in re.findall(r"\d+|\D+", str(s))]
 
 @st.cache_data(show_spinner=False, ttl=300)


### PR DESCRIPTION
## Summary
- Expand A1 entry titles to include "Assignment" for consistent naming.
- Update natural_key helper docstring to match new naming pattern.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b42aec7d748321ba1653dc001c5f38