### PR TITLE
Fix A1 10 answer numbering

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -150,10 +150,11 @@
       "Answer3": "A) Ein halbes Kilo",
       "Answer4": "B) 10 Euro",
       "Answer5": "B) Einen schönen Tag",
-      "Answer6": "Falsch Wahr",
-      "Answer7": "Falsch",
+      "Answer6": "Falsch",
+      "Answer7": "Wahr",
       "Answer8": "Falsch",
-      "Answer9": "Falsch"
+      "Answer9": "Falsch",
+      "Answer10": "Falsch"
     },
     "answer_url": "https://example.com/reference/A1%2010"
   },


### PR DESCRIPTION
## Summary
- Split combined "Falsch Wahr" entry into separate answers
- Add missing true/false responses to align numbering in A1 10

## Testing
- `python -m json.tool answers_dictionary.json`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b42ae89b048321a0febe125e9f8db8