### PR TITLE
Move AnswerN keys into nested answers dict

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,11 +79,15 @@ def load_answers_dictionary() -> Dict[str, Any]:
             for k, v in data.items():
                 if not isinstance(v, dict):
                     data[k] = {"answers": {}, "answer_url": ""}
+                    v = data[k]
                 else:
                     if "answers" not in v:
                         v["answers"] = {}
                     if "answer_url" not in v:
                         v["answer_url"] = ""
+                # move any top-level AnswerN keys into the nested "answers" dict
+                for ans_key in [kk for kk in list(v.keys()) if re.match(r"^Answer\d+", kk)]:
+                    v["answers"][ans_key] = v.pop(ans_key)
             return data
     st.error("❌ answers_dictionary.json not found in the repo.")
     return {}


### PR DESCRIPTION
## Summary
- Migrate legacy `AnswerN` fields in `answers_dictionary.json` entries into each assignment's `answers` dict during load.
- Ensure `build_reference_text` works with the normalized structure.

## Testing
- `python -m py_compile app.py`
- Loaded `load_answers_dictionary` and confirmed `Assignment 2` returns a populated `answers` dict and `build_reference_text` assembles it correctly.

------
https://chatgpt.com/codex/tasks/task_e_68b4331332ac83218acff8a3c3ae658d