### PR TITLE
feat: tailor AI marking to student level

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ Run the app with:
 ```bash
 streamlit run app.py
 ```
+
+### Using `ai_mark`
+
+If you want to use the AI marking helper directly in Python code, call `ai_mark` with the student's answer, reference text, and the student's level:
+
+```python
+from app import ai_mark
+
+score, feedback = ai_mark("Ich bin ein Student", "Ich bin eine Studentin", "A1")
+```
+
+`score` will be an integer from 0–100 (or `None` if the OpenAI key is missing) and `feedback` is a short tutor-style message tailored to the specified student level.

--- a/app.py
+++ b/app.py
@@ -184,14 +184,27 @@ def fetch_submissions(student_code: str) -> List[Dict[str, Any]]:
     if not items: pull("lessens")
     return items
 
-def ai_mark(student_answer: str, ref_text: str) -> Tuple[int | None, str]:
+def ai_mark(student_answer: str, ref_text: str, student_level: str) -> Tuple[int | None, str]:
+    """Mark a student's answer against the reference answer using OpenAI.
+
+    Args:
+        student_answer: The student's submission.
+        ref_text: The reference answer to compare against.
+        student_level: The student's proficiency level (e.g., A1, B2).
+
+    Returns:
+        Tuple of (score, feedback). Score is ``None`` if the AI client is unavailable.
+    """
     if not ai_client:
         return None, "⚠️ OpenAI key missing."
     prompt = f"""
-You are a German teacher. Compare the student's answer with the reference answer.
+You are the student's German tutor. The student is at level {student_level}. Compare the student's answer with the reference answer and judge it according to that level.
 Return STRICT JSON with:
 - score: integer 0-100
-- feedback: ~40 words, constructive.
+- feedback: ~40 words in a friendly, encouraging tutor voice.
+
+Student level:
+{student_level}
 
 Student answer:
 {student_answer}
@@ -435,7 +448,7 @@ if "ai_score" not in st.session_state:    st.session_state.ai_score = 0
 if "ai_feedback" not in st.session_state: st.session_state.ai_feedback = ""
 cur_key = f"{studentcode}|{st.session_state.ref_assignment}|{student_text[:60]}"
 if ai_client and student_text.strip() and st.session_state.ref_text.strip() and st.session_state.get("ai_key") != cur_key:
-    s, fb = ai_mark(student_text, st.session_state.ref_text)
+    s, fb = ai_mark(student_text, st.session_state.ref_text, student_level)
     if s is not None: st.session_state.ai_score = s
     st.session_state.ai_feedback = fb
     st.session_state.ai_key = cur_key
@@ -443,7 +456,7 @@ if ai_client and student_text.strip() and st.session_state.ref_text.strip() and 
 colA, colB = st.columns(2)
 with colA:
     if st.button("🔁 Regenerate AI"):
-        s, fb = ai_mark(student_text, st.session_state.ref_text)
+        s, fb = ai_mark(student_text, st.session_state.ref_text, student_level)
         if s is not None: st.session_state.ai_score = s
         st.session_state.ai_feedback = fb
 


### PR DESCRIPTION
## Summary
- allow `ai_mark` to accept a `student_level` parameter and personalize its prompt
- pass student level to AI marking calls
- document new usage of `ai_mark`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b489b1b7188321b8cac8d98fac415c