### PR TITLE
feat: add rubric-level feedback editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ Run the app with:
 ```bash
 streamlit run app.py
 ```
+
+## Editing rubric feedback
+
+The AI now produces separate feedback for each rubric criterion (grammar and vocabulary).
+Each comment is displayed in its own text area so instructors can review and edit before
+saving. When saved, the comments are combined into the overall `comments` field and also
+stored individually (e.g., `comment_grammar`, `comment_vocabulary`).


### PR DESCRIPTION
## Summary
- request rubric-specific feedback from AI and parse per criterion
- show editable text boxes for each rubric comment and save individually or combined
- document how to edit criterion-level feedback

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b489ce55048321a57bec4aa8b281bb