### PR TITLE
docs: clarify feedback block and remove rubric notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This Streamlit app is used to review student submissions against reference answers.
 
+The AI provides a single feedback block of roughly forty words, pointing out exact mistakes and reminding students to enter umlauted characters.
+
 ## Configuration
 
 Settings can be supplied through `streamlit` secrets or environment variables.
@@ -26,11 +28,4 @@ Run the app with:
 ```bash
 streamlit run app.py
 ```
-
-## Editing rubric feedback
-
-The AI now produces separate feedback for each rubric criterion (grammar and vocabulary).
-Each comment is displayed in its own text area so instructors can review and edit before
-saving. When saved, the comments are combined into the overall `comments` field and also
-stored individually (e.g., `comment_grammar`, `comment_vocabulary`).
 


### PR DESCRIPTION
## Summary
- Remove obsolete "Editing rubric feedback" section and comment_grammar/comment_vocabulary references
- Describe new single ~40-word feedback block with umlaut reminder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b48fe58bf88321a9d4cba13652d5b4