### PR TITLE
Define rubric criteria constant for AI feedback

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,9 @@ ANSWER_SOURCE = (
 if ANSWER_SOURCE not in ("json", "sheet"):
     ANSWER_SOURCE = ""
 
+# Criteria used for rubric-based AI feedback
+RUBRIC_CRITERIA = ["overall"]
+
 
 # =========================================================
 # Helpers


### PR DESCRIPTION
## Summary
- Add configurable `RUBRIC_CRITERIA` constant to centralize AI feedback rubric settings.
- Ensure AI feedback dictionary uses the new constant.

## Testing
- `python -m py_compile app.py`
- Stubbed `ai_client` and called `ai_mark` to confirm no NameError and correct feedback structure.


------
https://chatgpt.com/codex/tasks/task_e_68b4939b014c83219c3f9b7277c3f7de