### PR TITLE
Fix feedback format to always use string

### DIFF
--- a/app.py
+++ b/app.py
@@ -231,8 +231,7 @@ Return only JSON.
         if not isinstance(fb_str, str):
             fb_str = str(fb_str)
         fb_str = fb_str.strip()
-        fb_dict = {c: fb_str for c in RUBRIC_CRITERIA}
-        return max(0, min(100, score)), fb_dict
+        return max(0, min(100, score)), fb_str
 
     except Exception as e:
         return None, f"(AI error: {e})"
@@ -462,7 +461,7 @@ if ai_client and student_text.strip() and st.session_state.ref_text.strip() and 
     if s is not None:
         st.session_state.ai_score = s
 
-    st.session_state.feedback = fb
+    st.session_state.feedback = fb if isinstance(fb, str) else json.dumps(fb, indent=2)
     st.session_state.ai_key = cur_key
 
 colA, colB = st.columns(2)
@@ -473,7 +472,7 @@ with colA:
         if s is not None:
             st.session_state.ai_score = s
 
-        st.session_state.feedback = fb
+        st.session_state.feedback = fb if isinstance(fb, str) else json.dumps(fb, indent=2)
 
 score = st.number_input("Score", 0, 100, value=int(st.session_state.ai_score))
 


### PR DESCRIPTION
## Summary
- Return AI feedback as a plain string instead of a per-criterion dict
- Cast AI feedback to a string at both call sites before storing in `st.session_state`

## Testing
- `streamlit run app.py --server.headless true`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4939f8a2c8321944ae4c350a76b5e