### PR TITLE
Support objective vs essay grading with format flag

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -12,7 +12,8 @@
       "Answer9": "C) Guten Abend",
       "Answer10": "D) Gute Nacht"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1AgS3Kb78KcvbJnZvZijM4-cBJ1PitCVnUwe19T4TMPQ/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1AgS3Kb78KcvbJnZvZijM4-cBJ1PitCVnUwe19T4TMPQ/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 0.2": {
     "answers": {
@@ -29,7 +30,8 @@
       "Answer11": "Schule",
       "Answer12": "Tisch"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1XJcdMuaivOh2JCnXi1b9E4l5qN4KldyDSRNHJgiHnBs/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1XJcdMuaivOh2JCnXi1b9E4l5qN4KldyDSRNHJgiHnBs/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 1.1": {
     "answers": {
@@ -38,7 +40,8 @@
       "Answer3": "A",
       "Answer4": "B"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1KCNaM0_sgbrPhYMm89iC8WRzSfQgz80qUO9EAoCpXuo/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1KCNaM0_sgbrPhYMm89iC8WRzSfQgz80qUO9EAoCpXuo/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 2": {
     "answers": {
@@ -58,7 +61,8 @@
       "Answer14": "1020 – tausendzwanzig",
       "Answer15": "8553 – achttausendfünfhundertdreiundfünfzig"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1OVDkJimsz7wZwNa4s4QccST3TFvLkqzt720P_CWPdD8/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1OVDkJimsz7wZwNa4s4QccST3TFvLkqzt720P_CWPdD8/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 1.2": {
     "answers": {
@@ -77,7 +81,8 @@
       "Answer13": "B) Tom",
       "Answer14": "A) In Berlin"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1NuId_slE2LVNXvhfwQvdjYaqtBGa78aBNVETEw2RMmY/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1NuId_slE2LVNXvhfwQvdjYaqtBGa78aBNVETEw2RMmY/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 4": {
     "answers": {
@@ -94,7 +99,8 @@
       "Answer11": "B) Paris",
       "Answer12": "A) Nach Spanien"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1SiYvtaw-LwoeCff7yxlpWsfENMlIbQRqfuh3MPobPOE/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1SiYvtaw-LwoeCff7yxlpWsfENMlIbQRqfuh3MPobPOE/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 6": {
     "answers": {
@@ -123,7 +129,8 @@
       "Answer23": "B",
       "Answer24": "C"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1yXUzZdoz-wKnorDUbg-7e_SGMklgUXNxGakDlw5chgA/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1yXUzZdoz-wKnorDUbg-7e_SGMklgUXNxGakDlw5chgA/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 5": {
     "answers": {
@@ -158,7 +165,8 @@
       "Answer29": "Wir putzen das Fenster",
       "Answer30": "Sie benutzen den Computer"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1d0dvYURPHf69KlJhToqOxn39V8GCcAsdrhrEAQ78phw/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1d0dvYURPHf69KlJhToqOxn39V8GCcAsdrhrEAQ78phw/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 7": {
     "answers": {
@@ -183,7 +191,8 @@
       "Answer19": "B) Um drei Uhr nachmittags",
       "Answer20": "B) Um sieben Uhr"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1dCI5BbOvfvI4RekolDshv19jyNFPmzenDSrgBMGL9Uk/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1dCI5BbOvfvI4RekolDshv19jyNFPmzenDSrgBMGL9Uk/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 8": {
     "answers": {
@@ -203,7 +212,8 @@
       "Answer14": "B) Tag. Monat. Jahr",
       "Answer15": "D) Montag"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1Y8Zk4BvzbE2MhD2Wh0VIDbxwPib9biQ2zR60gaIQDYQ/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1Y8Zk4BvzbE2MhD2Wh0VIDbxwPib9biQ2zR60gaIQDYQ/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 9": {
     "answers": {
@@ -223,7 +233,8 @@
       "Answer14": "A) Käse",
       "Answer15": "C) Schokoladenkuchen"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1paS9hx9oc7iB2VnxGSUg5Y9-hMf8l08nCNGNSU4__SA/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1paS9hx9oc7iB2VnxGSUg5Y9-hMf8l08nCNGNSU4__SA/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 10": {
     "answers": {
@@ -243,7 +254,8 @@
       "Answer14": "B) 10 Euro",
       "Answer15": "B) Einen schönen Tag"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1OOxtH3ZuP6Vd8wfZScnV_Ht1ywke1C3OmFm5_kFrVGs/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1OOxtH3ZuP6Vd8wfZScnV_Ht1ywke1C3OmFm5_kFrVGs/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 11": {
     "answers": {
@@ -264,7 +276,8 @@
       "Answer15": "Rechts abbiegen: 'Biegen Sie rechts ab'",
       "Answer16": "On the left side: 'Das Kino ist auf der linken Seite'"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1kGGQZ89YZV-xGUdFKIHUFOVYG7wB7PnCBF8DqBd4Zok/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1kGGQZ89YZV-xGUdFKIHUFOVYG7wB7PnCBF8DqBd4Zok/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 12.1": {
     "answers": {
@@ -284,7 +297,8 @@
       "Answer14": "A) Richtig",
       "Answer15": "A) Richtig"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1vgjfS9u_dS8ypgMOkCkVp3j_04dM8hwGvQiJdCKT74c/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1vgjfS9u_dS8ypgMOkCkVp3j_04dM8hwGvQiJdCKT74c/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 12.2": {
     "answers": {
@@ -304,7 +318,8 @@
       "Answer14": "C) in einer Bar",
       "Answer15": "C) bar"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1DiO7gh0xrt-SyWWhpxVNtMs9lFjEGuzqJww9OMmTjDY/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1DiO7gh0xrt-SyWWhpxVNtMs9lFjEGuzqJww9OMmTjDY/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 13": {
     "answers": {
@@ -318,7 +333,8 @@
       "Answer8": "B",
       "Answer9": "B"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1VOz1kZqSXitbHO6ciV4GbGSZJkwXiZM1ifSxPVlvNNA/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1VOz1kZqSXitbHO6ciV4GbGSZJkwXiZM1ifSxPVlvNNA/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A1 Assignment 14.1": {
     "answers": {
@@ -338,7 +354,8 @@
       "Answer14": "i. Foot – Fuß",
       "Answer15": "j. Stomach / Belly – Bauch"
     },
-    "answer_url": "https://docs.google.com/spreadsheets/d/1FUBXLMY-KhlaDrFbsgKIuHRENalKdl5Zdlqb4Td9Yds/gviz/tq?tqx=out:html&sheet=Key"
+    "answer_url": "https://docs.google.com/spreadsheets/d/1FUBXLMY-KhlaDrFbsgKIuHRENalKdl5Zdlqb4Td9Yds/gviz/tq?tqx=out:html&sheet=Key",
+    "format": "objective"
   },
   "A2 1.1 Small Talk": {
     "answers": {
@@ -356,7 +373,8 @@
       "Answer12": "C) Einen Spaziergang Machen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1bENY4-5AG9hrgaDKqyNpTwKT02i58wGva6tVRn-hhbE/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1bENY4-5AG9hrgaDKqyNpTwKT02i58wGva6tVRn-hhbE/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1bENY4-5AG9hrgaDKqyNpTwKT02i58wGva6tVRn-hhbE/edit",
+    "format": "objective"
   },
   "A2 1.2 Personen Beschreiben": {
     "answers": {
@@ -372,7 +390,8 @@
       "Answer10": "A) Jeden tag"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1rjZ3kemRqOJIfZCX2GwQKMt715GRdo0M90IfKdzOGH0/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1rjZ3kemRqOJIfZCX2GwQKMt715GRdo0M90IfKdzOGH0/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1rjZ3kemRqOJIfZCX2GwQKMt715GRdo0M90IfKdzOGH0/edit",
+    "format": "objective"
   },
   "A2 1.3 Dinge und Personen vergleichen": {
     "answers": {
@@ -390,7 +409,8 @@
       "Answer12": "B) Julia und Tobias kochen am Wochenende oft mit Sophie"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1ftIKdxbCKTlcDJUj7uHNWZu-dRfH_Tuja0FzTgS_97M/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1ftIKdxbCKTlcDJUj7uHNWZu-dRfH_Tuja0FzTgS_97M/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1ftIKdxbCKTlcDJUj7uHNWZu-dRfH_Tuja0FzTgS_97M/edit",
+    "format": "objective"
   },
   "A2 2.4 Wo möchten wir uns treffen?": {
     "answers": {
@@ -406,7 +426,8 @@
       "Answer10": "A) Spielen und Spazieren gehen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Fy36SwyPWJOPXpAPJjIck6JLTdhIlrk11l6KYw1umvk/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1Fy36SwyPWJOPXpAPJjIck6JLTdhIlrk11l6KYw1umvk/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1Fy36SwyPWJOPXpAPJjIck6JLTdhIlrk11l6KYw1umvk/edit",
+    "format": "objective"
   },
   "A2 2.5 Was machst du in deiner Freizeit": {
     "answers": {
@@ -422,7 +443,8 @@
       "Answer10": "B) Klassische Musik"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/13s4XR4XAKonwV9KVjT-MOw5wXW6b99l3PMmuod7xu7w/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/13s4XR4XAKonwV9KVjT-MOw5wXW6b99l3PMmuod7xu7w/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/13s4XR4XAKonwV9KVjT-MOw5wXW6b99l3PMmuod7xu7w/edit",
+    "format": "objective"
   },
   "A2 3.6 Möbel und Räume kennenlernen": {
     "answers": {
@@ -438,7 +460,8 @@
       "Answer10": "B"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eMuNXnkWU_AQr422gKKkm8v6-MQTY7B7pzIEXjt5q3s/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1eMuNXnkWU_AQr422gKKkm8v6-MQTY7B7pzIEXjt5q3s/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1eMuNXnkWU_AQr422gKKkm8v6-MQTY7B7pzIEXjt5q3s/edit",
+    "format": "objective"
   },
   "A2 3.7 Eine Wohnung suchen": {
     "answers": {
@@ -456,7 +479,8 @@
       "Answer12": "B) 150 Euro"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eeiY8L1DYMjbBYjXAy9sPfw_gQt2-WrYAYcPGoeN1d4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1eeiY8L1DYMjbBYjXAy9sPfw_gQt2-WrYAYcPGoeN1d4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1eeiY8L1DYMjbBYjXAy9sPfw_gQt2-WrYAYcPGoeN1d4/edit",
+    "format": "objective"
   },
   "A2 3.8 Rezepte und Essen": {
     "answers": {
@@ -474,7 +498,8 @@
       "Answer12": "A) Gemuselasagne"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Qdiqusfbg9sqkrkspHljsD3vJPKb0bghFGskL8tCPp0/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1Qdiqusfbg9sqkrkspHljsD3vJPKb0bghFGskL8tCPp0/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1Qdiqusfbg9sqkrkspHljsD3vJPKb0bghFGskL8tCPp0/edit",
+    "format": "objective"
   },
   "A2 4.9 Urlaub": {
     "answers": {
@@ -492,7 +517,8 @@
       "Answer12": "A) Nach Kreta zu reisen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1YxZ2noWRoB12-oYlPxhum_LPPShshjQvyXOqnwymtAw/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1YxZ2noWRoB12-oYlPxhum_LPPShshjQvyXOqnwymtAw/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1YxZ2noWRoB12-oYlPxhum_LPPShshjQvyXOqnwymtAw/edit",
+    "format": "objective"
   },
   "A2 4.10 Tourismus und Traditionelle Feste": {
     "answers": {
@@ -510,7 +536,8 @@
       "Answer12": "B) Fahrgeschafte und Spiele"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1fhMpgMdfNWuZcoRnXMvKhGxXBJLYF-cGV4hyPHmcFu4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1fhMpgMdfNWuZcoRnXMvKhGxXBJLYF-cGV4hyPHmcFu4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1fhMpgMdfNWuZcoRnXMvKhGxXBJLYF-cGV4hyPHmcFu4/edit",
+    "format": "objective"
   },
   "A2 4.11 Unterwegs: Verkehrsmittel vergleichen": {
     "answers": {
@@ -528,7 +555,8 @@
       "Answer12": "B) Das Auto auf mögliche"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/16aS6UmVL-kQqcje1f3rDeqobEnkoNsxUwCNE_iBokI4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/16aS6UmVL-kQqcje1f3rDeqobEnkoNsxUwCNE_iBokI4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/16aS6UmVL-kQqcje1f3rDeqobEnkoNsxUwCNE_iBokI4/edit",
+    "format": "objective"
   },
   "A2 5.12 Ein Tag im Leben": {
     "answers": {
@@ -546,7 +574,8 @@
       "Answer12": "C) Vor 18 Uhr"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1z8wEWz-HJxm1DUvr0a7OE5md3Gj4OR5ZJ3SpJNI-hyQ/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1z8wEWz-HJxm1DUvr0a7OE5md3Gj4OR5ZJ3SpJNI-hyQ/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1z8wEWz-HJxm1DUvr0a7OE5md3Gj4OR5ZJ3SpJNI-hyQ/edit",
+    "format": "objective"
   },
   "A2 5.13 Ein Vorstellungsgespräch": {
     "answers": {
@@ -564,7 +593,8 @@
       "Answer12": "B) Klar und deutlich sprechen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1fySC84kZ7Xl1YfzmK4FaZImNjVI6wsr_YFi-4mfdrm4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1fySC84kZ7Xl1YfzmK4FaZImNjVI6wsr_YFi-4mfdrm4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1fySC84kZ7Xl1YfzmK4FaZImNjVI6wsr_YFi-4mfdrm4/edit",
+    "format": "objective"
   },
   "A2 5.14 Beruf und Karriere": {
     "answers": {
@@ -582,7 +612,8 @@
       "Answer12": "C) In der Volkshochschule"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1wKcE29sav7yHsSc9SSOwrbmtq15MF33LbVAeDaz4CAw/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1wKcE29sav7yHsSc9SSOwrbmtq15MF33LbVAeDaz4CAw/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1wKcE29sav7yHsSc9SSOwrbmtq15MF33LbVAeDaz4CAw/edit",
+    "format": "objective"
   },
   "A2 6.15 Mein Lieblingssport": {
     "answers": {
@@ -600,7 +631,8 @@
       "Answer12": "B) Volleyball und Basketball"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/11cVglcrlXHA5N9UBp5S6Mepm2KFP57Cp__4F2GRLRcM/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/11cVglcrlXHA5N9UBp5S6Mepm2KFP57Cp__4F2GRLRcM/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/11cVglcrlXHA5N9UBp5S6Mepm2KFP57Cp__4F2GRLRcM/edit",
+    "format": "objective"
   },
   "A2 6.16 Wohlbefinden und Entspannung": {
     "answers": {
@@ -616,7 +648,8 @@
       "Answer10": "A) Yoga und Pilates"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/13fG-McZz3Q_rmcHymAwfLwX7C1illz91v5b2yXyoArI/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/13fG-McZz3Q_rmcHymAwfLwX7C1illz91v5b2yXyoArI/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/13fG-McZz3Q_rmcHymAwfLwX7C1illz91v5b2yXyoArI/edit",
+    "format": "objective"
   },
   "A2 6.17 In die Apotheke gehen": {
     "answers": {
@@ -634,7 +667,8 @@
       "Answer12": "B) Proben von Produkten"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1X-H0rjHjyJeTbm_bVNh_Bp8VMT-ZwZBQdhadUS1Coqs/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1X-H0rjHjyJeTbm_bVNh_Bp8VMT-ZwZBQdhadUS1Coqs/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1X-H0rjHjyJeTbm_bVNh_Bp8VMT-ZwZBQdhadUS1Coqs/edit",
+    "format": "objective"
   },
   "A2 7.18 Die Bank Anrufen": {
     "answers": {
@@ -650,7 +684,8 @@
       "Answer10": "D) Die Formulare vor dem Termin online ausfüllen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/11swMhsZxMZKG8YqavvspmntM6RzTtP5NDG6zk19GskI/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/11swMhsZxMZKG8YqavvspmntM6RzTtP5NDG6zk19GskI/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/11swMhsZxMZKG8YqavvspmntM6RzTtP5NDG6zk19GskI/edit",
+    "format": "objective"
   },
   "A2 7.19 Einkaufen? Wo und wie?": {
     "answers": {
@@ -668,7 +703,8 @@
       "Answer12": "B) Es hat den Konsum revolutioniert und neue Möglichkeiten geschaffen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1OaEeNnHmG3brY-OhbHDpFmj86YUMLIqzMOEAlpAcnFE/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1OaEeNnHmG3brY-OhbHDpFmj86YUMLIqzMOEAlpAcnFE/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1OaEeNnHmG3brY-OhbHDpFmj86YUMLIqzMOEAlpAcnFE/edit",
+    "format": "objective"
   },
   "A2 7.20 Typische Reklamationssituationen üben": {
     "answers": {
@@ -687,7 +723,8 @@
       "Answer13": "B) Sie arbeiteten mehr und hatten weniger Freizeit"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1C-utAPIEGi9Rsp_gI3qsfHddX9IXvazP27sxRrobI40/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1C-utAPIEGi9Rsp_gI3qsfHddX9IXvazP27sxRrobI40/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1C-utAPIEGi9Rsp_gI3qsfHddX9IXvazP27sxRrobI40/edit",
+    "format": "objective"
   },
   "A2 8.21 Ein Wochenende planen": {
     "answers": {
@@ -698,7 +735,8 @@
       "Answer5": "A) Den Berufsweg eines Kochs"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/16SKkqpJNa7NyqrnH5xyiyD5VH6AmmyJWG4dc2SiIVO4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/16SKkqpJNa7NyqrnH5xyiyD5VH6AmmyJWG4dc2SiIVO4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/16SKkqpJNa7NyqrnH5xyiyD5VH6AmmyJWG4dc2SiIVO4/edit",
+    "format": "objective"
   },
   "A2 8.22 Die Woche Plannung": {
     "answers": {
@@ -709,7 +747,8 @@
       "Answer5": "C) Übernachtet Sonja in Marios Zimmer."
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1IltGaPYHb_jPazZNClHdjzTu-Tgs94zfHNzixrizvCs/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1IltGaPYHb_jPazZNClHdjzTu-Tgs94zfHNzixrizvCs/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1IltGaPYHb_jPazZNClHdjzTu-Tgs94zfHNzixrizvCs/edit",
+    "format": "objective"
   },
   "A2 9.23 Wie kommst du zur Schule / zur Arbeit?": {
     "answers": {
@@ -720,7 +759,8 @@
       "Answer5": "D) Die Berge und die Natur"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1u7kFhf4yTXKlRhxVNsr7nmDfaR1XBnkzwG6ZnIwvAmo/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1u7kFhf4yTXKlRhxVNsr7nmDfaR1XBnkzwG6ZnIwvAmo/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1u7kFhf4yTXKlRhxVNsr7nmDfaR1XBnkzwG6ZnIwvAmo/edit",
+    "format": "objective"
   },
   "A2 9.24 Einen Urlaub planen": {
     "answers": {
@@ -731,7 +771,8 @@
       "Answer5": "Anzeige: a"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1VhkmUp18ZHieB-bTyZavqvEs1ikz9bXAHh_aDOai-7E/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1VhkmUp18ZHieB-bTyZavqvEs1ikz9bXAHh_aDOai-7E/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1VhkmUp18ZHieB-bTyZavqvEs1ikz9bXAHh_aDOai-7E/edit",
+    "format": "objective"
   },
   "A2 9.25 Tagesablauf": {
     "answers": {
@@ -747,7 +788,8 @@
       "Answer10": "b) das Zimmer ist zu klein"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1nOtlOXVblDt1RQ8JOLpBBLQfjmnxJ9YF6ylhZo4u6kY/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1nOtlOXVblDt1RQ8JOLpBBLQfjmnxJ9YF6ylhZo4u6kY/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1nOtlOXVblDt1RQ8JOLpBBLQfjmnxJ9YF6ylhZo4u6kY/edit",
+    "format": "objective"
   },
   "A2 10.26 Gefühle in verschiedenen Situationen beschr": {
     "answers": {
@@ -760,7 +802,8 @@
       "Answer7": "b) An speziellen Freizeitangeboten in der Stadt teilnehmen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1SQsUUW6_A3X-SGbOsyMZuOgm6Qo7gGsnqY9pbNxYgmY/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1SQsUUW6_A3X-SGbOsyMZuOgm6Qo7gGsnqY9pbNxYgmY/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1SQsUUW6_A3X-SGbOsyMZuOgm6Qo7gGsnqY9pbNxYgmY/edit",
+    "format": "objective"
   },
   "A2 10.27 Digitale Kommunikation": {
     "answers": {
@@ -773,7 +816,8 @@
       "Answer7": "d) Mit öffentlichem WLAN"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1CDLU1BEBm-xCS0BEdXunjSN8CHol1UMuxlF_QDSGNc8/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1CDLU1BEBm-xCS0BEdXunjSN8CHol1UMuxlF_QDSGNc8/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1CDLU1BEBm-xCS0BEdXunjSN8CHol1UMuxlF_QDSGNc8/edit",
+    "format": "objective"
   },
   "A2 10.28 Über die Zukunft sprechen": {
     "answers": {
@@ -786,7 +830,8 @@
       "Answer7": "c) Kranken-, Renten- und Pflegeversicherung"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1fAP60NXAKiJ8wdugvjQtZxDX-3ap88vKya7yZWo9mEs/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1fAP60NXAKiJ8wdugvjQtZxDX-3ap88vKya7yZWo9mEs/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1fAP60NXAKiJ8wdugvjQtZxDX-3ap88vKya7yZWo9mEs/edit",
+    "format": "objective"
   },
   "B1 1.1 Traumwelten": {
     "answers": {
@@ -804,7 +849,8 @@
       "Answer12": "A) In der REM-Phase"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1hKJ2W9aka4qCSMg_tYpbrAQPvw1ON2GrlvJYbjJHe54/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1hKJ2W9aka4qCSMg_tYpbrAQPvw1ON2GrlvJYbjJHe54/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1hKJ2W9aka4qCSMg_tYpbrAQPvw1ON2GrlvJYbjJHe54/edit",
+    "format": "objective"
   },
   "B1 1.2 Freundes für Leben": {
     "answers": {
@@ -822,7 +868,8 @@
       "Answer12": "B) Fehler zu vergeben"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1M8ZeJrG3z1CjUhE09QCEf2p7XtruShjQl-8EzEfWvIQ/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1M8ZeJrG3z1CjUhE09QCEf2p7XtruShjQl-8EzEfWvIQ/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1M8ZeJrG3z1CjUhE09QCEf2p7XtruShjQl-8EzEfWvIQ/edit",
+    "format": "objective"
   },
   "B1 1.3 Erfolgsgeschichten": {
     "answers": {
@@ -840,7 +887,8 @@
       "Answer12": "A) Erschopft aber zufrieden"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1EjYVFY9Krq_MmyeBMVUDhOyb8lFLOD_8X0Rg9qpR4G4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1EjYVFY9Krq_MmyeBMVUDhOyb8lFLOD_8X0Rg9qpR4G4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1EjYVFY9Krq_MmyeBMVUDhOyb8lFLOD_8X0Rg9qpR4G4/edit",
+    "format": "objective"
   },
   "B1 2.4 Wohnung suchen": {
     "answers": {
@@ -858,7 +906,8 @@
       "Answer12": "B) Es gibt eine U-Bahn Station und mehree Bushaltestellen in der Nahe"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/18GckqSrP1SJkHpBuUKlk0yvstL2q6Je10IxmK6vt4XE/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/18GckqSrP1SJkHpBuUKlk0yvstL2q6Je10IxmK6vt4XE/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/18GckqSrP1SJkHpBuUKlk0yvstL2q6Je10IxmK6vt4XE/edit",
+    "format": "objective"
   },
   "B1 2.5 Der Besichtigungsg termin": {
     "answers": {
@@ -876,7 +925,8 @@
       "Answer12": "B) Gehaltsnachweise und Mieterselbstauskunft"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eQ3oZh5sV9O-ybmCLnxlxjfxIqrCVoa5HpVcszE_Fv0/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1eQ3oZh5sV9O-ybmCLnxlxjfxIqrCVoa5HpVcszE_Fv0/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1eQ3oZh5sV9O-ybmCLnxlxjfxIqrCVoa5HpVcszE_Fv0/edit",
+    "format": "objective"
   },
   "B1 2.6 Leben in der Stadt oder auf dem Land?": {
     "answers": {
@@ -894,7 +944,8 @@
       "Answer12": "B) Mischung aus Privatsphare und sozialer interaktion"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1JXeoYk5ruXOZblqVFx6chD5tMxs8lMA5mDAX3KQwNpE/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1JXeoYk5ruXOZblqVFx6chD5tMxs8lMA5mDAX3KQwNpE/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1JXeoYk5ruXOZblqVFx6chD5tMxs8lMA5mDAX3KQwNpE/edit",
+    "format": "objective"
   },
   "B1 3.7 Fast Food vs. Hausmannskost": {
     "answers": {
@@ -917,7 +968,8 @@
       "Answer17": "B) Den Zuckerkonsum zu reduzieren und mehr frische Lebensmittel zu essen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1COQA_nlpRTk-FTLD5fL3HkWoVAvUh0XVrpc4TLE3i-w/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1COQA_nlpRTk-FTLD5fL3HkWoVAvUh0XVrpc4TLE3i-w/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1COQA_nlpRTk-FTLD5fL3HkWoVAvUh0XVrpc4TLE3i-w/edit",
+    "format": "objective"
   },
   "B1 3.8 Alles für die Gesundheit": {
     "answers": {
@@ -935,7 +987,8 @@
       "Answer12": "B) Sie sehen ihn als einen stillen Helden"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eLDjlTYn2coRP8HsnZvH1FURNcNY0jUmGtUF9-4pRY4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1eLDjlTYn2coRP8HsnZvH1FURNcNY0jUmGtUF9-4pRY4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1eLDjlTYn2coRP8HsnZvH1FURNcNY0jUmGtUF9-4pRY4/edit",
+    "format": "objective"
   },
   "B1 3.9 Work-Life-Balance im modernen Arbeitsumfeld": {
     "answers": {
@@ -953,7 +1006,8 @@
       "Answer12": "B) Sie helfen, das wohibefinden zu steigern"
     },
     "answer_url": "",
-    "sheet_url": ""
+    "sheet_url": "",
+    "format": "objective"
   },
   "B1 4.10 Digitale Auszeit und Selbstfürsorge": {
     "answers": {
@@ -971,7 +1025,8 @@
       "Answer12": "C) Gefuhle der Einsamkeit und Isolation"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1rpXdbptzIH1c2xSYb1Kz3c7lRsCshNMyqFa-eMtfS_s/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1rpXdbptzIH1c2xSYb1Kz3c7lRsCshNMyqFa-eMtfS_s/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1rpXdbptzIH1c2xSYb1Kz3c7lRsCshNMyqFa-eMtfS_s/edit",
+    "format": "objective"
   },
   "B1 4.11 Teamspiele und Kooperative Aktivitäten": {
     "answers": {
@@ -989,7 +1044,8 @@
       "Answer12": "A) Traditionelle Spiele Haben Soziale und Korperliche Vorteile"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1bd1xCfp9UE7LHJ_dINYIFU4ZBafXFWe1Qdt5Yq0DsJQ/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1bd1xCfp9UE7LHJ_dINYIFU4ZBafXFWe1Qdt5Yq0DsJQ/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1bd1xCfp9UE7LHJ_dINYIFU4ZBafXFWe1Qdt5Yq0DsJQ/edit",
+    "format": "objective"
   },
   "B1 4.12 Abenteuer in der Natur": {
     "answers": {
@@ -1007,7 +1063,8 @@
       "Answer12": "B"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1_MAR_-rTWz4xhS1Oz0D3fd6Rstd10Q8zP1Dc9jHBCcc/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1_MAR_-rTWz4xhS1Oz0D3fd6Rstd10Q8zP1Dc9jHBCcc/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1_MAR_-rTWz4xhS1Oz0D3fd6Rstd10Q8zP1Dc9jHBCcc/edit",
+    "format": "objective"
   },
   "B1 4.13 Eigene Filmkritik schreiben": {
     "answers": {
@@ -1025,7 +1082,8 @@
       "Answer12": "C) Weil sie Abenteuer ohne echte Gefahr erleben wollen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1BY62D8rPhp8DeGFNZP6uV6Tk3K7Iz5BdjPrZUifyv4s/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1BY62D8rPhp8DeGFNZP6uV6Tk3K7Iz5BdjPrZUifyv4s/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1BY62D8rPhp8DeGFNZP6uV6Tk3K7Iz5BdjPrZUifyv4s/edit",
+    "format": "objective"
   },
   "B1 5.14 Traditionelles vs. digitales Lernen": {
     "answers": {
@@ -1043,7 +1101,8 @@
       "Answer12": "C) RegelmaBig und in kleinen Schritten lernen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1sdKVEIqVZzqzYlTuEmpXv1W0ozkovfGjoIDFrKvjguM/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1sdKVEIqVZzqzYlTuEmpXv1W0ozkovfGjoIDFrKvjguM/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1sdKVEIqVZzqzYlTuEmpXv1W0ozkovfGjoIDFrKvjguM/edit",
+    "format": "objective"
   },
   "B1 5.15 Medien und Arbeiten im Homeoffice": {
     "answers": {
@@ -1061,7 +1120,8 @@
       "Answer12": "C) Balance zwischen digitalem und realem Leben finden"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Ukcoo644zSndWMdtK4RE9UKT9eCAQo3MFyzySkGERKs/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1Ukcoo644zSndWMdtK4RE9UKT9eCAQo3MFyzySkGERKs/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1Ukcoo644zSndWMdtK4RE9UKT9eCAQo3MFyzySkGERKs/edit",
+    "format": "objective"
   },
   "B1 5.16 Prüfungsangst und Stressbewältigung": {
     "answers": {
@@ -1079,7 +1139,8 @@
       "Answer12": "C) Negative Gedanken und Stress"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Yzmp1pDDBIK8axqKMMb48neT1U9qWSrMojawHWz4gok/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1Yzmp1pDDBIK8axqKMMb48neT1U9qWSrMojawHWz4gok/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1Yzmp1pDDBIK8axqKMMb48neT1U9qWSrMojawHWz4gok/edit",
+    "format": "objective"
   },
   "B1 5.17 Wie lernt man am besten?": {
     "answers": {
@@ -1097,7 +1158,8 @@
       "Answer12": "B) Sich selbst belohnen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/17FL2CY2xn5tHSaaysDTypMsuevxzUtAyfpNVhQtKsX4/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/17FL2CY2xn5tHSaaysDTypMsuevxzUtAyfpNVhQtKsX4/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/17FL2CY2xn5tHSaaysDTypMsuevxzUtAyfpNVhQtKsX4/edit",
+    "format": "objective"
   },
   "B1 6.18 Wege zum Wunschberuf": {
     "answers": {
@@ -1115,7 +1177,8 @@
       "Answer12": "C) Flexibel sein und sich anpassen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1g_zdXMGP06wWELi9fIiM8eDfRzgHUAMOCwcrkUTaLiM/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1g_zdXMGP06wWELi9fIiM8eDfRzgHUAMOCwcrkUTaLiM/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1g_zdXMGP06wWELi9fIiM8eDfRzgHUAMOCwcrkUTaLiM/edit",
+    "format": "objective"
   },
   "B1 6.19 Das Vorstellungsgespräch": {
     "answers": {
@@ -1127,7 +1190,8 @@
       "Answer6": "C) mehr Velo-Touristen in die Region kommen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1jIci1aX6N68DhttbtTg1yLF2ighuNIyYNTtSLz_OEjc/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1jIci1aX6N68DhttbtTg1yLF2ighuNIyYNTtSLz_OEjc/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1jIci1aX6N68DhttbtTg1yLF2ighuNIyYNTtSLz_OEjc/edit",
+    "format": "objective"
   },
   "B1 6.20 Wie wird man ?? (Ausbildung und Qu)": {
     "answers": {
@@ -1139,7 +1203,8 @@
       "Answer6": "B) Falsch"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1MaHnVgNn_PC74l5bfjPJp84Of1xGkL-kXneLL9awNHg/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1MaHnVgNn_PC74l5bfjPJp84Of1xGkL-kXneLL9awNHg/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1MaHnVgNn_PC74l5bfjPJp84Of1xGkL-kXneLL9awNHg/edit",
+    "format": "objective"
   },
   "B1 7.21 Lebensformen heute ? Familie, Wohnge": {
     "answers": {
@@ -1150,7 +1215,8 @@
       "Answer5": "C) Weil ihre Eltern dort wohnen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Cr7l9lPtiR5KvB7twzyc3FM12OiTTfLow9fu7JfnEU8/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1Cr7l9lPtiR5KvB7twzyc3FM12OiTTfLow9fu7JfnEU8/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1Cr7l9lPtiR5KvB7twzyc3FM12OiTTfLow9fu7JfnEU8/edit",
+    "format": "objective"
   },
   "B1 7.22 Was ist dir in einer Beziehung wichtig?": {
     "answers": {
@@ -1166,7 +1232,8 @@
       "Answer10": "C) Man kann sich bei der nächsten offenen Stelle bewerben."
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1b4CY4c1YK-QrIKmmq6NX60cdmWJ6u0X6C-qcyoFjbBU/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1b4CY4c1YK-QrIKmmq6NX60cdmWJ6u0X6C-qcyoFjbBU/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1b4CY4c1YK-QrIKmmq6NX60cdmWJ6u0X6C-qcyoFjbBU/edit",
+    "format": "objective"
   },
   "B1 7.23 Erstes Date ? Typische Situationen": {
     "answers": {
@@ -1179,7 +1246,8 @@
       "Answer7": "B) Mary Pilon"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1gHdQ_M00rJyQkHvK30p-mI_ZY3tk7gMGCTjTpL1drOk/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1gHdQ_M00rJyQkHvK30p-mI_ZY3tk7gMGCTjTpL1drOk/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1gHdQ_M00rJyQkHvK30p-mI_ZY3tk7gMGCTjTpL1drOk/edit",
+    "format": "objective"
   },
   "B1 8.24 Konsum und Nachhaltigkeit": {
     "answers": {
@@ -1190,7 +1258,8 @@
       "Answer5": "True"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1WdDtfi_8MfBJpXrZUj_ypsDqyyAp3DuMhIiB_FNjGnc/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1WdDtfi_8MfBJpXrZUj_ypsDqyyAp3DuMhIiB_FNjGnc/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1WdDtfi_8MfBJpXrZUj_ypsDqyyAp3DuMhIiB_FNjGnc/edit",
+    "format": "objective"
   },
   "B1 8.25 Online einkaufen ? Rechte und Risiken": {
     "answers": {
@@ -1203,7 +1272,8 @@
       "Answer7": "B) Broschüren mit Informationen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1qD3fjXMprCDY-5Xz1-msUH1DgA9_V8KbwxTInF0I0AE/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1qD3fjXMprCDY-5Xz1-msUH1DgA9_V8KbwxTInF0I0AE/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1qD3fjXMprCDY-5Xz1-msUH1DgA9_V8KbwxTInF0I0AE/edit",
+    "format": "objective"
   },
   "B1 9.26 Reiseprobleme und Lösungen": {
     "answers": {
@@ -1215,7 +1285,8 @@
       "Answer6": "C) Weil das Wetter in Deutschland nicht immer sonnig und warm ist"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1o3axSLfa47e16kvcL2zJP5FdtYXTbOwYAEzQ4Xen1VI/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1o3axSLfa47e16kvcL2zJP5FdtYXTbOwYAEzQ4Xen1VI/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1o3axSLfa47e16kvcL2zJP5FdtYXTbOwYAEzQ4Xen1VI/edit",
+    "format": "objective"
   },
   "B1 10.27 Umweltfreundlich im Alltag": {
     "answers": {
@@ -1233,7 +1304,8 @@
       "Answer12": "B) Bei jedem Einzelnen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/14lfVVKeZkgYlfg3QOArxlRoNddpAFM0SfKwzfit9ZNU/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/14lfVVKeZkgYlfg3QOArxlRoNddpAFM0SfKwzfit9ZNU/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/14lfVVKeZkgYlfg3QOArxlRoNddpAFM0SfKwzfit9ZNU/edit",
+    "format": "objective"
   },
   "B1 10.28 Klimafreundlich leben": {
     "answers": {
@@ -1251,7 +1323,7 @@
       "Answer12": "B"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1ZmpTcbi4zR5gxGt80Khu3E2M-1sneiJM0qCOCwa8UKo/gviz/tq?tqx=out:html&sheet=Key",
-    "sheet_url": "https://docs.google.com/spreadsheets/d/1ZmpTcbi4zR5gxGt80Khu3E2M-1sneiJM0qCOCwa8UKo/edit"
+    "sheet_url": "https://docs.google.com/spreadsheets/d/1ZmpTcbi4zR5gxGt80Khu3E2M-1sneiJM0qCOCwa8UKo/edit",
+    "format": "objective"
   }
 }
-


### PR DESCRIPTION
## Summary
- add `format` flag to reference data and JSON model
- propagate format and raw answers through helpers and session state
- grade objective assignments via direct answer comparison without AI

## Testing
- `python -m py_compile app.py`
- `python -m json.tool answers_dictionary.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b4996c7c34832195deb129cdc248ce