### PR TITLE
Show drafts for all students

### DIFF
--- a/pages/new_drafts.py
+++ b/pages/new_drafts.py
@@ -66,33 +66,54 @@ def fetch_submissions(student_code: str) -> List[Dict[str, Any]]:
     return items
 
 
+def fetch_all_submissions() -> List[Dict[str, Any]]:
+    """Fetch submissions for all students under ``drafts_v2``.
+
+    Each entry in the returned list contains a ``student_code`` identifying the
+    source document along with the submission data.
+    """
+    if not db:
+        return []
+
+    items: List[Dict[str, Any]] = []
+    try:
+        for doc in db.collection("drafts_v2").stream():
+            code = doc.id
+            for coll in ["lessons", "lessens"]:
+                try:
+                    for snap in doc.reference.collection(coll).stream():
+                        d = snap.to_dict() or {}
+                        d["id"] = snap.id
+                        d["student_code"] = code
+                        items.append(d)
+                except Exception:
+                    pass
+    except Exception:
+        pass
+    return items
+
+
 st.title("New Drafts")
 st_autorefresh(interval=5000, key="new_drafts_refresh")
 
-student_code = st.session_state.get("studentcode") or st.sidebar.text_input("Student code")
-if student_code:
-    st.session_state.studentcode = student_code
-
-if not student_code:
-    st.info("Enter a student code to view drafts.")
+subs = fetch_all_submissions()
+if not subs:
+    st.info("No drafts found.")
 else:
-    subs = fetch_submissions(student_code)
-    if not subs:
-        st.info("No drafts found.")
+    subs = sorted(subs, key=lambda d: d.get("timestamp", 0), reverse=True)
+    if st.checkbox("Show as table"):
+        import pandas as pd
+        st.dataframe(pd.DataFrame(subs))
     else:
-        subs = sorted(subs, key=lambda d: d.get("timestamp", 0), reverse=True)
-        if st.checkbox("Show as table"):
-            import pandas as pd
-            st.dataframe(pd.DataFrame(subs))
-        else:
-            for doc in subs:
-                ts = doc.get("timestamp", "")
-                if isinstance(ts, (int, float)):
-                    ts_str = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d %H:%M:%S")
-                else:
-                    ts_str = str(ts)
-                lesson = doc.get("lesson") or doc.get("assignment") or ""
-                content = extract_text_from_doc(doc)
-                with st.container():
-                    st.markdown(f"**{ts_str} — {lesson}**")
-                    st.markdown(content or "(empty)")
+        for doc in subs:
+            ts = doc.get("timestamp", "")
+            if isinstance(ts, (int, float)):
+                ts_str = datetime.fromtimestamp(ts / 1000).strftime("%Y-%m-%d %H:%M:%S")
+            else:
+                ts_str = str(ts)
+            lesson = doc.get("lesson") or doc.get("assignment") or ""
+            student_code = doc.get("student_code", "")
+            content = extract_text_from_doc(doc)
+            with st.container():
+                st.markdown(f"**{ts_str} — {lesson} — {student_code}**")
+                st.markdown(content or "(empty)")


### PR DESCRIPTION
## Summary
- Add `fetch_all_submissions` to aggregate lessons/lessens across all student documents in `drafts_v2`
- Remove student code sidebar and render all drafts with student code in metadata

## Testing
- `pytest >/tmp/unit.log ; tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b6154bdf648321a600e0c0d5d349d4