### PR TITLE
Refactor Firestore initialization into helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,15 +15,9 @@ except Exception:  # pragma: no cover - allow running without plugin
         return None
 
 # ---------------- Firebase ----------------
-import firebase_admin
-from firebase_admin import credentials, firestore
+from firebase_utils import get_firestore_client
 
-if not firebase_admin._apps:
-    fb_cfg = st.secrets.get("firebase")
-    if fb_cfg:
-        cred = credentials.Certificate(dict(fb_cfg))
-        firebase_admin.initialize_app(cred)
-db = firestore.client() if firebase_admin._apps else None
+db = get_firestore_client()
 
 # ---------------- IDs / Config ----------------
 # Students Google Sheet (tab now "Sheet1" unless you override in secrets)

--- a/firebase_utils.py
+++ b/firebase_utils.py
@@ -1,0 +1,33 @@
+"""Utility helpers for working with Firebase/Firestore."""
+
+from __future__ import annotations
+
+import firebase_admin
+from firebase_admin import credentials, firestore
+import streamlit as st
+
+
+def get_firestore_client():
+    """Return a Firestore client, initializing Firebase if needed.
+
+    The function attempts to obtain the default Firebase app using
+    :func:`firebase_admin.get_app`.  If no app has been initialized yet a
+    ``ValueError`` is raised, in which case we try to initialize it with
+    credentials loaded from ``st.secrets['firebase']``.  When initialization
+    cannot be completed (e.g. missing secrets) ``None`` is returned.
+    """
+
+    try:
+        app = firebase_admin.get_app()
+    except ValueError:
+        fb_cfg = st.secrets.get("firebase")
+        if not fb_cfg:
+            return None
+        cred = credentials.Certificate(dict(fb_cfg))
+        app = firebase_admin.initialize_app(cred)
+
+    try:
+        return firestore.client(app)
+    except ValueError:
+        return None
+

--- a/pages/new_drafts.py
+++ b/pages/new_drafts.py
@@ -13,16 +13,9 @@ except Exception:  # pragma: no cover
         return None
 
 # ---- Firebase setup ----
-import firebase_admin
-from firebase_admin import credentials, firestore
+from firebase_utils import get_firestore_client
 
-if not firebase_admin._apps:
-    fb_cfg = st.secrets.get("firebase")
-    if fb_cfg:
-        cred = credentials.Certificate(dict(fb_cfg))
-        firebase_admin.initialize_app(cred)
-
-db = firestore.client() if firebase_admin._apps else None
+db = get_firestore_client()
 
 # Show which Firestore project we’re connected to
 if db:


### PR DESCRIPTION
## Summary
- add `firebase_utils.get_firestore_client` to centralize Firebase app initialization
- use new helper in `app.py` and `pages/new_drafts.py`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b62436bf04832182eba964a8a3ea2d