### PR TITLE
Use helper for duplicate account detection

### DIFF
--- a/account_utils.py
+++ b/account_utils.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class Account:
+    """Simple representation of a student account."""
+    name: str
+    email: str
+    level: str
+    student_code: str
+
+
+def is_duplicate_account(existing: Account, candidate: Account) -> bool:
+    """Return ``True`` if ``candidate`` is a duplicate of ``existing``.
+
+    Two accounts are considered duplicates when both the ``name`` and
+    ``email`` match *and* either the ``level`` or the ``student_code``
+    is identical.  This mirrors the helper described in the issue which
+    performs a more nuanced comparison than simply checking name and
+    email equality.
+    """
+    same_name = existing.name.strip().lower() == candidate.name.strip().lower()
+    same_email = existing.email.strip().lower() == candidate.email.strip().lower()
+    if not (same_name and same_email):
+        return False
+    return (
+        existing.level.strip().lower() == candidate.level.strip().lower()
+        or existing.student_code.strip().lower() == candidate.student_code.strip().lower()
+    )
+
+
+def has_similar_account(candidate: Account, accounts: Iterable[Account]) -> bool:
+    """Return ``True`` if any account in ``accounts`` is a duplicate of
+    ``candidate``.
+
+    This function previously compared name and email directly but now
+    delegates the decision to :func:`is_duplicate_account`.  Only when
+    the helper reports a duplicate do we flag the account.
+    """
+    for acc in accounts:
+        if is_duplicate_account(acc, candidate):
+            return True
+    return False

--- a/tests/test_duplicate_account.py
+++ b/tests/test_duplicate_account.py
@@ -1,0 +1,23 @@
+import os
+import sys
+
+# Ensure project root is on the import path for local imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from account_utils import Account, has_similar_account
+
+
+def test_same_name_email_different_level_and_code_no_warning():
+    existing = [
+        Account(name="Jane Doe", email="jane@example.com", level="A1", student_code="a100"),
+    ]
+    candidate = Account(name="Jane Doe", email="jane@example.com", level="B2", student_code="b200")
+    assert not has_similar_account(candidate, existing)
+
+
+def test_duplicate_detected_when_level_matches():
+    existing = [
+        Account(name="Jane Doe", email="jane@example.com", level="A1", student_code="a100"),
+    ]
+    candidate = Account(name="Jane Doe", email="jane@example.com", level="A1", student_code="b200")
+    assert has_similar_account(candidate, existing)


### PR DESCRIPTION
## Summary
- add `is_duplicate_account` and use it in `has_similar_account`
- test duplicate detection logic and ensure benign cases aren't warned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b80c1c67a48321b7f3b7951a6ce34a