### PR TITLE
Handle non-2xx responses in score saving

### DIFF
--- a/app.py
+++ b/app.py
@@ -499,6 +499,10 @@ def save_row_to_scores(row: dict) -> dict:
 
         raw = r.text  # keep a copy for troubleshooting
 
+        # Bail out early if the request failed
+        if not (200 <= r.status_code < 300):
+            return {"ok": False, "status": r.status_code, "raw": raw}
+
         # ---------------- Structured JSON ----------------
         if r.headers.get("content-type", "").startswith("application/json"):
             data: Dict[str, Any]

--- a/tests/test_save_row_to_scores.py
+++ b/tests/test_save_row_to_scores.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import ast
+
+# Ensure project root is on import path if needed
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import requests
+
+
+def _load_save_row_to_scores():
+    path = os.path.join(os.path.dirname(__file__), "..", "app.py")
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename="app.py")
+    func_node = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "save_row_to_scores")
+    module = ast.Module(body=[func_node], type_ignores=[])
+    namespace = {
+        "requests": requests,
+        "WEBHOOK_URL": "https://example.com",
+        "WEBHOOK_TOKEN": "token",
+    }
+    exec(compile(module, "app.py", "exec"), namespace)
+    return namespace["save_row_to_scores"]
+
+
+def test_save_row_to_scores_non_2xx(monkeypatch):
+    save_row_to_scores = _load_save_row_to_scores()
+
+    class DummyResponse:
+        status_code = 400
+        text = "Bad request"
+        headers = {}
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResponse())
+
+    result = save_row_to_scores({"foo": "bar"})
+    assert result == {"ok": False, "status": 400, "raw": "Bad request"}


### PR DESCRIPTION
## Summary
- Fail fast if the score-saving webhook responds with a non-2xx status, returning the status code and raw body.
- Add unit test verifying save_row_to_scores reports failure for 400 responses.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb645b148c83219f902886a79379e8