### PR TITLE
Handle successful scores upload

### DIFF
--- a/app.py
+++ b/app.py
@@ -522,14 +522,15 @@ def save_row_to_scores(row: dict) -> dict:
                         "raw": raw,
                     }
 
-                # Ensure raw message is included for debugging
+                # Ensure raw message is included for debugging and default to success
                 data.setdefault("raw", raw)
+                data.setdefault("ok", True)
                 return data
 
         # ---------------- Fallback: plain text ----------------
         if "violates the data validation rules" in raw:
             return {"ok": False, "why": "validation", "raw": raw}
-        return {"ok": False, "raw": raw}
+        return {"ok": True, "raw": raw}
 
     except Exception as e:
         return {"ok": False, "error": str(e)}
@@ -556,6 +557,8 @@ def save_row(row: dict, to_sheet: bool = True, to_firestore: bool = False) -> di
         first failure returned.
     """
 
+    result: Dict[str, Any] = {"ok": True}
+
     if to_sheet:
         result = save_row_to_scores(row)
         if not result.get("ok"):
@@ -566,7 +569,7 @@ def save_row(row: dict, to_sheet: bool = True, to_firestore: bool = False) -> di
         if not result.get("ok"):
             return result
 
-    return {"ok": True}
+    return result
 
 
 

--- a/tests/test_save_row_to_scores.py
+++ b/tests/test_save_row_to_scores.py
@@ -35,3 +35,17 @@ def test_save_row_to_scores_non_2xx(monkeypatch):
 
     result = save_row_to_scores({"foo": "bar"})
     assert result == {"ok": False, "status": 400, "raw": "Bad request"}
+
+
+def test_save_row_to_scores_success_default(monkeypatch):
+    save_row_to_scores = _load_save_row_to_scores()
+
+    class DummyResponse:
+        status_code = 200
+        text = "All good"
+        headers = {}
+
+    monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResponse())
+
+    result = save_row_to_scores({"foo": "bar"})
+    assert result == {"ok": True, "raw": "All good"}


### PR DESCRIPTION
## Summary
- Treat scores webhook 2xx responses as success when no structured error is present
- Return sheet upload details from save_row
- Test save_row_to_scores happy-path behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb722f57508321b75cb2a381cade5b