### PR TITLE
Add detailed success messages for save operations

### DIFF
--- a/firebase_utils.py
+++ b/firebase_utils.py
@@ -45,8 +45,8 @@ def save_row_to_firestore(row: dict, collection: str = "scores") -> dict:
     Returns
     -------
     dict
-        ``{"ok": True}`` on success or ``{"ok": False, "error": str}`` on
-        failure.
+        ``{"ok": True, "message": "Saved to Firestore"}`` on success or
+        ``{"ok": False, "error": str}`` on failure.
     """
 
     db = get_firestore_client()
@@ -55,7 +55,7 @@ def save_row_to_firestore(row: dict, collection: str = "scores") -> dict:
 
     try:
         db.collection(collection).add(row)
-        return {"ok": True}
+        return {"ok": True, "message": "Saved to Firestore"}
     except Exception as e:  # pragma: no cover - broad to capture Firestore errors
         return {"ok": False, "error": str(e)}
 

--- a/tests/test_firestore_utils.py
+++ b/tests/test_firestore_utils.py
@@ -23,6 +23,6 @@ def test_save_row_to_firestore_success(monkeypatch):
     monkeypatch.setattr(firebase_utils, 'get_firestore_client', lambda: FakeClient())
 
     result = firebase_utils.save_row_to_firestore({'foo': 'bar'})
-    assert result == {'ok': True}
+    assert result == {'ok': True, 'message': 'Saved to Firestore'}
     assert added['collection'] == 'scores'
     assert added['row'] == {'foo': 'bar'}

--- a/tests/test_save_row_to_scores.py
+++ b/tests/test_save_row_to_scores.py
@@ -48,4 +48,4 @@ def test_save_row_to_scores_success_default(monkeypatch):
     monkeypatch.setattr(requests, "post", lambda *a, **k: DummyResponse())
 
     result = save_row_to_scores({"foo": "bar"})
-    assert result == {"ok": True, "raw": "All good"}
+    assert result == {"ok": True, "raw": "All good", "message": "Saved to Scores sheet"}


### PR DESCRIPTION
## Summary
- return a success message from Firestore saves
- include a message when saving rows to the Scores sheet
- aggregate save operation messages and display them in the UI
- extend tests to check for success messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbfb9d841483218e92b7a6636a8ca0