### PR TITLE
Fix JSON formatting around A2 7.20 answers

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -794,12 +794,12 @@
         "Answer2": "A) Man sollte die Firma recherchieren, um gut informiert zu sein; B) Man sollte den Arbeitsweg üben, um pünktlich zu sein",
         "Answer3": "A) Die Bezahlung, weil man finanziell abgesichert sein möchte; B) Die Arbeitszeiten, weil man eine gute Work-Life-Balance haben möchte",
         "Answer4": "A) Frauen haben oft geringere Aufstiegschancen. Eine Lösung wäre eine Frauenquote.; B) Frauen verdienen häufig weniger als Männer. Transparente Gehaltsstrukturen könnten helfen.; C) Frauen müssen oft Beruf und Familie vereinbaren. Flexible Arbeitszeiten könnten eine Lösung sein.",
-        "Answer5": "A) Es gab weniger technische Geräte im Haushalt; B) Die Menschen waren weniger mobil und reisten seltener.; D) Die Arbeitszeiten waren länger und härter",
+        "Answer5": "A) Es gab weniger technische Geräte im Haushalt; B) Die Menschen waren weniger mobil und reisten seltener.; D) Die Arbeitszeiten waren länger und härter"
 
       },
       "teil4": {
         "Answer1": "B) Die Berufliche",
-        "Answer2": "B) Man informiert sich"
+        "Answer2": "B) Man informiert sich",
         "Answer3": "A) Die Bezahlung",
         "Answer4": "A) Man sammelt",
         "Answer5": "A) Geringere",


### PR DESCRIPTION
## Summary
- remove the stray trailing comma from the final entry in the A2 7.20 `teil3` answers so the JSON object closes cleanly
- add the missing comma after the second answer in the corresponding `teil4` section to keep the object well formed

## Testing
- python -m json.tool answers_dictionary.json

------
https://chatgpt.com/codex/tasks/task_e_68d26e4ac4e083218c28534b0c3ed36a