### PR TITLE
Include assignment ID in Google Sheets save payload

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -13,7 +13,8 @@
       "Answer10": "D) Gute Nacht"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1AgS3Kb78KcvbJnZvZijM4-cBJ1PitCVnUwe19T4TMPQ/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-0.1"
   },
   "A1 Alphabets 0.2": {
     "answers": {
@@ -31,7 +32,8 @@
       "Answer12": "Tisch"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1XJcdMuaivOh2JCnXi1b9E4l5qN4KldyDSRNHJgiHnBs/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-0.2"
   },
   "A1 Personal Pronouns 1.1": {
     "answers": {
@@ -41,7 +43,8 @@
       "Answer4": "B Hamburg"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1KCNaM0_sgbrPhYMm89iC8WRzSfQgz80qUO9EAoCpXuo/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-1.1"
   },
   "A1 Numbers 2": {
     "answers": {
@@ -62,7 +65,8 @@
       "Answer15": "8553 – achttausendfünfhundertdreiundfünfzig"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1OVDkJimsz7wZwNa4s4QccST3TFvLkqzt720P_CWPdD8/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-2"
   },
   "A1 Pronouns 1.2": {
     "answers": {
@@ -82,7 +86,8 @@
       "Answer14": "A) In Berlin"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1NuId_slE2LVNXvhfwQvdjYaqtBGa78aBNVETEw2RMmY/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-1.2"
   },
   "A1 Countries and Languages 4": {
     "answers": {
@@ -100,7 +105,8 @@
       "Answer12": "A) Nach Spanien"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1SiYvtaw-LwoeCff7yxlpWsfENMlIbQRqfuh3MPobPOE/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-4"
   },
   "A1 Objects and Colors 6": {
     "answers": {
@@ -130,7 +136,8 @@
       "Answer24": "C"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1yXUzZdoz-wKnorDUbg-7e_SGMklgUXNxGakDlw5chgA/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-6"
   },
   "A1 German Cases 5": {
     "answers": {
@@ -166,7 +173,8 @@
       "Answer30": "Sie benutzen den Computer"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1d0dvYURPHf69KlJhToqOxn39V8GCcAsdrhrEAQ78phw/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-5"
   },
   "A1 12 Hour Clock 7": {
     "answers": {
@@ -192,7 +200,8 @@
       "Answer20": "B) Um sieben Uhr"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1dCI5BbOvfvI4RekolDshv19jyNFPmzenDSrgBMGL9Uk/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-12"
   },
   "A1 24 Hour Clock 8": {
     "answers": {
@@ -213,7 +222,8 @@
       "Answer15": "D) Montag"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Y8Zk4BvzbE2MhD2Wh0VIDbxwPib9biQ2zR60gaIQDYQ/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-24"
   },
   "A1 Negation 9": {
     "answers": {
@@ -234,7 +244,8 @@
       "Answer15": "C) Schokoladenkuchen"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1paS9hx9oc7iB2VnxGSUg5Y9-hMf8l08nCNGNSU4__SA/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-9"
   },
   "A1 Food 10": {
     "answers": {
@@ -255,7 +266,8 @@
       "Answer15": "B) Einen schönen Tag"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1OOxtH3ZuP6Vd8wfZScnV_Ht1ywke1C3OmFm5_kFrVGs/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-10"
   },
   "A1 Instructions 11": {
     "answers": {
@@ -282,7 +294,8 @@
       }
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1kGGQZ89YZV-xGUdFKIHUFOVYG7wB7PnCBF8DqBd4Zok/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-11"
   },
   "A1 Two Case Preposition 12.1": {
     "answers": {
@@ -309,7 +322,8 @@
       }
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1vgjfS9u_dS8ypgMOkCkVp3j_04dM8hwGvQiJdCKT74c/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-12.1"
   },
   "A1 Two Case Preposition 12.2": {
     "answers": {
@@ -336,12 +350,14 @@
       }
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1DiO7gh0xrt-SyWWhpxVNtMs9lFjEGuzqJww9OMmTjDY/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-12.2"
   },
   "Introduction to Letter Writing  12.3": {
     "answers": {
       "Answer1": "Read comment for answers"
-    }
+    },
+    "assignment_id": "A1-12.3"
   },
   "A1 Weather 13": {
     "answers": {
@@ -356,7 +372,8 @@
       "Answer9": "B"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1VOz1kZqSXitbHO6ciV4GbGSZJkwXiZM1ifSxPVlvNNA/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-13"
   },
   "A1 Health 14.1": {
     "answers": {
@@ -377,7 +394,8 @@
       "Answer15": "j. Stomach / Belly – Bauch"
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1FUBXLMY-KhlaDrFbsgKIuHRENalKdl5Zdlqb4Td9Yds/gviz/tq?tqx=out:html&sheet=Key",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A1-14.1"
   },
   "A2 1.1 Small Talk": {
     "answers": {
@@ -400,7 +418,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1bENY4-5AG9hrgaDKqyNpTwKT02i58wGva6tVRn-hhbE/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1bENY4-5AG9hrgaDKqyNpTwKT02i58wGva6tVRn-hhbE/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-1.1"
   },
   "A2 1.2 Personen Beschreiben": {
     "answers": {
@@ -421,7 +440,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1rjZ3kemRqOJIfZCX2GwQKMt715GRdo0M90IfKdzOGH0/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1rjZ3kemRqOJIfZCX2GwQKMt715GRdo0M90IfKdzOGH0/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-1.2"
   },
   "A2 1.3 Dinge und Personen vergleichen": {
     "answers": {
@@ -444,7 +464,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1ftIKdxbCKTlcDJUj7uHNWZu-dRfH_Tuja0FzTgS_97M/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1ftIKdxbCKTlcDJUj7uHNWZu-dRfH_Tuja0FzTgS_97M/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-1.3"
   },
   "A2 2.4 Wo möchten wir uns treffen?": {
     "answers": {
@@ -466,7 +487,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Fy36SwyPWJOPXpAPJjIck6JLTdhIlrk11l6KYw1umvk/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1Fy36SwyPWJOPXpAPJjIck6JLTdhIlrk11l6KYw1umvk/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-2.4"
   },
   "A2 2.5 Was machst du in deiner Freizeit": {
     "answers": {
@@ -487,7 +509,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/13s4XR4XAKonwV9KVjT-MOw5wXW6b99l3PMmuod7xu7w/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/13s4XR4XAKonwV9KVjT-MOw5wXW6b99l3PMmuod7xu7w/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-2.5"
   },
   "A2 3.6 Möbel und Räume kennenlernen": {
     "answers": {
@@ -510,7 +533,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eMuNXnkWU_AQr422gKKkm8v6-MQTY7B7pzIEXjt5q3s/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1eMuNXnkWU_AQr422gKKkm8v6-MQTY7B7pzIEXjt5q3s/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-3.6"
   },
   "A2 3.7 Eine Wohnung suchen": {
     "answers": {
@@ -533,7 +557,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eeiY8L1DYMjbBYjXAy9sPfw_gQt2-WrYAYcPGoeN1d4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1eeiY8L1DYMjbBYjXAy9sPfw_gQt2-WrYAYcPGoeN1d4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-3.7"
   },
   "A2 3.8 Rezepte und Essen": {
     "answers": {
@@ -556,7 +581,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Qdiqusfbg9sqkrkspHljsD3vJPKb0bghFGskL8tCPp0/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1Qdiqusfbg9sqkrkspHljsD3vJPKb0bghFGskL8tCPp0/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-3.8"
   },
   "A2 4.9 Urlaub": {
     "answers": {
@@ -579,7 +605,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1YxZ2noWRoB12-oYlPxhum_LPPShshjQvyXOqnwymtAw/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1YxZ2noWRoB12-oYlPxhum_LPPShshjQvyXOqnwymtAw/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-4.9"
   },
   "A2 4.10 Tourismus und Traditionelle Feste": {
     "answers": {
@@ -602,7 +629,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1fhMpgMdfNWuZcoRnXMvKhGxXBJLYF-cGV4hyPHmcFu4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1fhMpgMdfNWuZcoRnXMvKhGxXBJLYF-cGV4hyPHmcFu4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-4.10"
   },
   "A2 4.11 Unterwegs: Verkehrsmittel vergleichen": {
     "answers": {
@@ -625,7 +653,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/16aS6UmVL-kQqcje1f3rDeqobEnkoNsxUwCNE_iBokI4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/16aS6UmVL-kQqcje1f3rDeqobEnkoNsxUwCNE_iBokI4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-4.11"
   },
   "A2 5.12 Ein Tag im Leben": {
     "answers": {
@@ -648,7 +677,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1z8wEWz-HJxm1DUvr0a7OE5md3Gj4OR5ZJ3SpJNI-hyQ/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1z8wEWz-HJxm1DUvr0a7OE5md3Gj4OR5ZJ3SpJNI-hyQ/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-5.12"
   },
   "A2 5.13 Ein Vorstellungsgespräch": {
     "answers": {
@@ -671,7 +701,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1fySC84kZ7Xl1YfzmK4FaZImNjVI6wsr_YFi-4mfdrm4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1fySC84kZ7Xl1YfzmK4FaZImNjVI6wsr_YFi-4mfdrm4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-5.13"
   },
   "A2 5.14 Beruf und Karriere": {
     "answers": {
@@ -694,7 +725,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1wKcE29sav7yHsSc9SSOwrbmtq15MF33LbVAeDaz4CAw/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1wKcE29sav7yHsSc9SSOwrbmtq15MF33LbVAeDaz4CAw/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-5.14"
   },
   "A2 6.15 Mein Lieblingssport": {
     "answers": {
@@ -717,7 +749,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/11cVglcrlXHA5N9UBp5S6Mepm2KFP57Cp__4F2GRLRcM/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/11cVglcrlXHA5N9UBp5S6Mepm2KFP57Cp__4F2GRLRcM/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-6.15"
   },
   "A2 6.16 Wohlbefinden und Entspannung": {
     "answers": {
@@ -738,7 +771,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/13fG-McZz3Q_rmcHymAwfLwX7C1illz91v5b2yXyoArI/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/13fG-McZz3Q_rmcHymAwfLwX7C1illz91v5b2yXyoArI/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-6.16"
   },
   "A2 6.17 In die Apotheke gehen": {
     "answers": {
@@ -761,7 +795,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1X-H0rjHjyJeTbm_bVNh_Bp8VMT-ZwZBQdhadUS1Coqs/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1X-H0rjHjyJeTbm_bVNh_Bp8VMT-ZwZBQdhadUS1Coqs/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-6.17"
   },
   "A2 7.18 Die Bank Anrufen": {
     "answers": {
@@ -782,7 +817,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/11swMhsZxMZKG8YqavvspmntM6RzTtP5NDG6zk19GskI/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/11swMhsZxMZKG8YqavvspmntM6RzTtP5NDG6zk19GskI/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-7.18"
   },
   "A2 7.19 Einkaufen? Wo und wie?": {
     "answers": {
@@ -805,7 +841,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1OaEeNnHmG3brY-OhbHDpFmj86YUMLIqzMOEAlpAcnFE/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1OaEeNnHmG3brY-OhbHDpFmj86YUMLIqzMOEAlpAcnFE/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-7.19"
   },
   "A2 7.20 Typische Reklamationssituationen üben": {
     "answers": {
@@ -829,7 +866,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1C-utAPIEGi9Rsp_gI3qsfHddX9IXvazP27sxRrobI40/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1C-utAPIEGi9Rsp_gI3qsfHddX9IXvazP27sxRrobI40/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-7.20"
   },
   "A2 8.21 Ein Wochenende planen": {
     "answers": {
@@ -844,7 +882,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/16SKkqpJNa7NyqrnH5xyiyD5VH6AmmyJWG4dc2SiIVO4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/16SKkqpJNa7NyqrnH5xyiyD5VH6AmmyJWG4dc2SiIVO4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-8.21"
   },
   "A2 8.22 Die Woche Plannung": {
     "answers": {
@@ -859,7 +898,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1IltGaPYHb_jPazZNClHdjzTu-Tgs94zfHNzixrizvCs/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1IltGaPYHb_jPazZNClHdjzTu-Tgs94zfHNzixrizvCs/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-8.22"
   },
   "A2 9.23 Wie kommst du zur Schule / zur Arbeit?": {
     "answers": {
@@ -874,7 +914,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1u7kFhf4yTXKlRhxVNsr7nmDfaR1XBnkzwG6ZnIwvAmo/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1u7kFhf4yTXKlRhxVNsr7nmDfaR1XBnkzwG6ZnIwvAmo/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-9.23"
   },
   "A2 9.24 Einen Urlaub planen": {
     "answers": {
@@ -889,7 +930,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1VhkmUp18ZHieB-bTyZavqvEs1ikz9bXAHh_aDOai-7E/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1VhkmUp18ZHieB-bTyZavqvEs1ikz9bXAHh_aDOai-7E/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-9.24"
   },
   "A2 9.25 Tagesablauf": {
     "answers": {
@@ -910,7 +952,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1nOtlOXVblDt1RQ8JOLpBBLQfjmnxJ9YF6ylhZo4u6kY/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1nOtlOXVblDt1RQ8JOLpBBLQfjmnxJ9YF6ylhZo4u6kY/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-9.25"
   },
   "A2 10.26 Gefühle in verschiedenen Situationen beschr": {
     "answers": {
@@ -927,7 +970,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1SQsUUW6_A3X-SGbOsyMZuOgm6Qo7gGsnqY9pbNxYgmY/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1SQsUUW6_A3X-SGbOsyMZuOgm6Qo7gGsnqY9pbNxYgmY/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-10.26"
   },
   "A2 10.27 Digitale Kommunikation": {
     "answers": {
@@ -944,7 +988,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1CDLU1BEBm-xCS0BEdXunjSN8CHol1UMuxlF_QDSGNc8/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1CDLU1BEBm-xCS0BEdXunjSN8CHol1UMuxlF_QDSGNc8/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-10.27"
   },
   "A2 10.28 Über die Zukunft sprechen": {
     "answers": {
@@ -961,7 +1006,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1fAP60NXAKiJ8wdugvjQtZxDX-3ap88vKya7yZWo9mEs/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1fAP60NXAKiJ8wdugvjQtZxDX-3ap88vKya7yZWo9mEs/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "A2-10.28"
   },
   "B1 1.1 Traumwelten": {
     "answers": {
@@ -984,7 +1030,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1hKJ2W9aka4qCSMg_tYpbrAQPvw1ON2GrlvJYbjJHe54/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1hKJ2W9aka4qCSMg_tYpbrAQPvw1ON2GrlvJYbjJHe54/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-1.1"
   },
   "B1 1.2 Freundes für Leben": {
     "answers": {
@@ -1007,7 +1054,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1M8ZeJrG3z1CjUhE09QCEf2p7XtruShjQl-8EzEfWvIQ/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1M8ZeJrG3z1CjUhE09QCEf2p7XtruShjQl-8EzEfWvIQ/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-1.2"
   },
   "B1 1.3 Erfolgsgeschichten": {
     "answers": {
@@ -1030,7 +1078,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1EjYVFY9Krq_MmyeBMVUDhOyb8lFLOD_8X0Rg9qpR4G4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1EjYVFY9Krq_MmyeBMVUDhOyb8lFLOD_8X0Rg9qpR4G4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-1.3"
   },
   "B1 2.4 Wohnung suchen": {
     "answers": {
@@ -1053,7 +1102,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/18GckqSrP1SJkHpBuUKlk0yvstL2q6Je10IxmK6vt4XE/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/18GckqSrP1SJkHpBuUKlk0yvstL2q6Je10IxmK6vt4XE/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-2.4"
   },
   "B1 2.5 Der Besichtigungsg termin": {
     "answers": {
@@ -1076,7 +1126,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eQ3oZh5sV9O-ybmCLnxlxjfxIqrCVoa5HpVcszE_Fv0/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1eQ3oZh5sV9O-ybmCLnxlxjfxIqrCVoa5HpVcszE_Fv0/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-2.5"
   },
   "B1 2.6 Leben in der Stadt oder auf dem Land?": {
     "answers": {
@@ -1099,7 +1150,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1JXeoYk5ruXOZblqVFx6chD5tMxs8lMA5mDAX3KQwNpE/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1JXeoYk5ruXOZblqVFx6chD5tMxs8lMA5mDAX3KQwNpE/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-2.6"
   },
   "B1 3.7 Fast Food vs. Hausmannskost": {
     "answers": {
@@ -1127,7 +1179,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1COQA_nlpRTk-FTLD5fL3HkWoVAvUh0XVrpc4TLE3i-w/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1COQA_nlpRTk-FTLD5fL3HkWoVAvUh0XVrpc4TLE3i-w/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-3.7"
   },
   "B1 3.8 Alles für die Gesundheit": {
     "answers": {
@@ -1150,7 +1203,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1eLDjlTYn2coRP8HsnZvH1FURNcNY0jUmGtUF9-4pRY4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1eLDjlTYn2coRP8HsnZvH1FURNcNY0jUmGtUF9-4pRY4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-3.8"
   },
   "B1 3.9 Work-Life-Balance im modernen Arbeitsumfeld": {
     "answers": {
@@ -1173,7 +1227,8 @@
     },
     "answer_url": "",
     "sheet_url": "",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-3.9"
   },
   "B1 4.10 Digitale Auszeit und Selbstfürsorge": {
     "answers": {
@@ -1196,7 +1251,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1rpXdbptzIH1c2xSYb1Kz3c7lRsCshNMyqFa-eMtfS_s/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1rpXdbptzIH1c2xSYb1Kz3c7lRsCshNMyqFa-eMtfS_s/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-4.10"
   },
   "B1 4.11 Teamspiele und Kooperative Aktivitäten": {
     "answers": {
@@ -1219,7 +1275,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1bd1xCfp9UE7LHJ_dINYIFU4ZBafXFWe1Qdt5Yq0DsJQ/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1bd1xCfp9UE7LHJ_dINYIFU4ZBafXFWe1Qdt5Yq0DsJQ/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-4.11"
   },
   "B1 4.12 Abenteuer in der Natur": {
     "answers": {
@@ -1242,7 +1299,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1_MAR_-rTWz4xhS1Oz0D3fd6Rstd10Q8zP1Dc9jHBCcc/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1_MAR_-rTWz4xhS1Oz0D3fd6Rstd10Q8zP1Dc9jHBCcc/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-4.12"
   },
   "B1 4.13 Eigene Filmkritik schreiben": {
     "answers": {
@@ -1265,7 +1323,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1BY62D8rPhp8DeGFNZP6uV6Tk3K7Iz5BdjPrZUifyv4s/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1BY62D8rPhp8DeGFNZP6uV6Tk3K7Iz5BdjPrZUifyv4s/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-4.13"
   },
   "B1 5.14 Traditionelles vs. digitales Lernen": {
     "answers": {
@@ -1288,7 +1347,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1sdKVEIqVZzqzYlTuEmpXv1W0ozkovfGjoIDFrKvjguM/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1sdKVEIqVZzqzYlTuEmpXv1W0ozkovfGjoIDFrKvjguM/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-5.14"
   },
   "B1 5.15 Medien und Arbeiten im Homeoffice": {
     "answers": {
@@ -1311,7 +1371,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Ukcoo644zSndWMdtK4RE9UKT9eCAQo3MFyzySkGERKs/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1Ukcoo644zSndWMdtK4RE9UKT9eCAQo3MFyzySkGERKs/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-5.15"
   },
   "B1 5.16 Prüfungsangst und Stressbewältigung": {
     "answers": {
@@ -1334,7 +1395,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Yzmp1pDDBIK8axqKMMb48neT1U9qWSrMojawHWz4gok/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1Yzmp1pDDBIK8axqKMMb48neT1U9qWSrMojawHWz4gok/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-5.16"
   },
   "B1 5.17 Wie lernt man am besten?": {
     "answers": {
@@ -1357,7 +1419,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/17FL2CY2xn5tHSaaysDTypMsuevxzUtAyfpNVhQtKsX4/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/17FL2CY2xn5tHSaaysDTypMsuevxzUtAyfpNVhQtKsX4/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-5.17"
   },
   "B1 6.18 Wege zum Wunschberuf": {
     "answers": {
@@ -1380,7 +1443,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1g_zdXMGP06wWELi9fIiM8eDfRzgHUAMOCwcrkUTaLiM/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1g_zdXMGP06wWELi9fIiM8eDfRzgHUAMOCwcrkUTaLiM/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-6.18"
   },
   "B1 6.19 Das Vorstellungsgespräch": {
     "answers": {
@@ -1396,7 +1460,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1jIci1aX6N68DhttbtTg1yLF2ighuNIyYNTtSLz_OEjc/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1jIci1aX6N68DhttbtTg1yLF2ighuNIyYNTtSLz_OEjc/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-6.19"
   },
   "B1 6.20 Wie wird man ?? (Ausbildung und Qu)": {
     "answers": {
@@ -1412,7 +1477,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1MaHnVgNn_PC74l5bfjPJp84Of1xGkL-kXneLL9awNHg/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1MaHnVgNn_PC74l5bfjPJp84Of1xGkL-kXneLL9awNHg/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-6.20"
   },
   "B1 7.21 Lebensformen heute ? Familie, Wohnge": {
     "answers": {
@@ -1427,7 +1493,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1Cr7l9lPtiR5KvB7twzyc3FM12OiTTfLow9fu7JfnEU8/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1Cr7l9lPtiR5KvB7twzyc3FM12OiTTfLow9fu7JfnEU8/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-7.21"
   },
   "B1 7.22 Was ist dir in einer Beziehung wichtig?": {
     "answers": {
@@ -1448,7 +1515,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1b4CY4c1YK-QrIKmmq6NX60cdmWJ6u0X6C-qcyoFjbBU/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1b4CY4c1YK-QrIKmmq6NX60cdmWJ6u0X6C-qcyoFjbBU/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-7.22"
   },
   "B1 7.23 Erstes Date ? Typische Situationen": {
     "answers": {
@@ -1465,7 +1533,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1gHdQ_M00rJyQkHvK30p-mI_ZY3tk7gMGCTjTpL1drOk/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1gHdQ_M00rJyQkHvK30p-mI_ZY3tk7gMGCTjTpL1drOk/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-7.23"
   },
   "B1 8.24 Konsum und Nachhaltigkeit": {
     "answers": {
@@ -1480,7 +1549,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1WdDtfi_8MfBJpXrZUj_ypsDqyyAp3DuMhIiB_FNjGnc/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1WdDtfi_8MfBJpXrZUj_ypsDqyyAp3DuMhIiB_FNjGnc/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-8.24"
   },
   "B1 8.25 Online einkaufen ? Rechte und Risiken": {
     "answers": {
@@ -1497,7 +1567,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1qD3fjXMprCDY-5Xz1-msUH1DgA9_V8KbwxTInF0I0AE/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1qD3fjXMprCDY-5Xz1-msUH1DgA9_V8KbwxTInF0I0AE/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-8.25"
   },
   "B1 9.26 Reiseprobleme und Lösungen": {
     "answers": {
@@ -1513,7 +1584,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1o3axSLfa47e16kvcL2zJP5FdtYXTbOwYAEzQ4Xen1VI/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1o3axSLfa47e16kvcL2zJP5FdtYXTbOwYAEzQ4Xen1VI/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-9.26"
   },
   "B1 10.27 Umweltfreundlich im Alltag": {
     "answers": {
@@ -1536,7 +1608,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/14lfVVKeZkgYlfg3QOArxlRoNddpAFM0SfKwzfit9ZNU/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/14lfVVKeZkgYlfg3QOArxlRoNddpAFM0SfKwzfit9ZNU/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-10.27"
   },
   "B1 10.28 Klimafreundlich leben": {
     "answers": {
@@ -1559,7 +1632,8 @@
     },
     "answer_url": "https://docs.google.com/spreadsheets/d/1ZmpTcbi4zR5gxGt80Khu3E2M-1sneiJM0qCOCwa8UKo/gviz/tq?tqx=out:html&sheet=Key",
     "sheet_url": "https://docs.google.com/spreadsheets/d/1ZmpTcbi4zR5gxGt80Khu3E2M-1sneiJM0qCOCwa8UKo/edit",
-    "format": "objective"
+    "format": "objective",
+    "assignment_id": "B1-10.28"
   },
   "A1 Asking About Prices 3": {
     "answers": {
@@ -1579,6 +1653,7 @@
         "Answer7": "Ich mag Reisen. / Ich mag nicht Reisen.",
         "Answer8": "Ich mag Gartenarbeit. / Ich mag nicht Gartenarbeit."
       }
-    }
+    },
+    "assignment_id": "A1-3"
   }
 }

--- a/app.py
+++ b/app.py
@@ -921,6 +921,8 @@ if "ref_format" not in st.session_state:
     st.session_state.ref_format = "essay"
 if "ref_answers" not in st.session_state:
     st.session_state.ref_answers = {}
+if "ref_assignment_id" not in st.session_state:
+    st.session_state.ref_assignment_id = ""
 
 (tab_json, tab_recent) = st.tabs(["📦 JSON dictionary", "🆕 New submissions"])
 
@@ -946,6 +948,7 @@ with tab_json:
             st.session_state.ref_link = link_json
             st.session_state.ref_format = fmt_json
             st.session_state.ref_answers = ans_map_json
+            st.session_state.ref_assignment_id = str((ans_dict.get(pick_json, {}) or {}).get("assignment_id", "")).strip()
             st.success("Using JSON reference")
 
 with tab_recent:
@@ -997,9 +1000,10 @@ if not st.session_state.ref_assignment:
         st.session_state.ref_link = ln
         st.session_state.ref_format = fmt
         st.session_state.ref_answers = ans_map
+        st.session_state.ref_assignment_id = str((ans[first] or {}).get("assignment_id", "")).strip()
 
 st.info(
-    f"Currently selected reference → **{st.session_state.ref_assignment or '—'}** (format: {st.session_state.ref_format})"
+    f"Currently selected reference → **{st.session_state.ref_assignment or '—'}** (format: {st.session_state.ref_format}, id: {st.session_state.ref_assignment_id or '—'})"
 )
 
 # ---------------- Submissions & Marking ----------------
@@ -1111,6 +1115,7 @@ if st.button("💾 Save", type="primary", use_container_width=True):
             "date": datetime.now().strftime("%Y-%m-%d"),
             "level": student_level,
             "link": link_value,
+            "assgnment_id": st.session_state.ref_assignment_id,
         }
 
         result = save_row(row, to_firestore=save_to_firestore)

--- a/firebase_utils.py
+++ b/firebase_utils.py
@@ -68,6 +68,7 @@ def save_row_to_firestore(row: dict, collection: str = "scores") -> dict:
                 "comments": row.get("comments"),
                 "date": row.get("date"),
                 "level": row.get("level"),
+                "assgnment_id": row.get("assgnment_id"),
             },
         }
         return {"ok": True, "message": "Saved to Firestore", "receipt": receipt}


### PR DESCRIPTION
### Motivation
- The Scores Google Sheet includes an `assgnment_id` column, so the app must send the matching assignment identifier when saving a student row. 
- Ensure the selected JSON reference's `assignment_id` is available in session state so saves never miss the ID.
- Surface the selected assignment ID in the UI for quick verification before saving.
- Provide consistent visibility of the assignment ID in Firestore receipts for debugging and record-keeping.

### Description
- Added `ref_assignment_id` to `st.session_state` and populate it when the user clicks `✅ Use this JSON reference` and when auto-loading the first JSON assignment. 
- Show the selected ID in the info line: `Currently selected reference → ... (format: ..., id: ...)`. 
- Include the `assgnment_id` field (spelling matches the sheet header) in the `row` payload sent to `save_row` / the Scores Google Sheet. 
- Add `assgnment_id` into the Firestore `saved_data` receipt in `save_row_to_firestore` for consistency. 
- Updated `answers_dictionary.json` entries to include `assignment_id` values so the UI can read and send them.

### Testing
- Verified Python syntax by running `python -m py_compile app.py firebase_utils.py`, which succeeded. 
- Searched the codebase for `ref_assignment_id`/`assgnment_id` occurrences with `rg` to confirm wiring into `app.py` and `firebase_utils.py`, which matched expectations. 
- Committed the changes and generated PR metadata for review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d7e36f1b88322ab7fd68a705b0f33)